### PR TITLE
v2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,40 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/rwfdg9d4i3g0qyga?svg=true)](https://ci.appveyor.com/project/skwasjer/correlate)
-[![NuGet](https://img.shields.io/nuget/v/Correlate.svg)](https://www.nuget.org/packages/Correlate/)
-[![Tests](https://img.shields.io/appveyor/tests/skwasjer/Correlate.svg)](https://ci.appveyor.com/project/skwasjer/correlate/build/tests)
-
 # Correlate
 
 Correlate provides flexible .NET Core support for correlation ID in ASP.NET Core and HttpClient.
 
-| Package | Description | 
-|---|---|
-| Correlate.Abstractions | Abstractions library. |
-| Correlate.Core | Core library, including a `DelegatingHandler` for `HttpClient`. |
-| Correlate.AspNetCore | ASP.NET Core middleware. |
-| Correlate.DependencyInjection | Extensions for registration in a `IServiceCollection` container. |
+## Installation
+
+Install Correlate via the Nuget package manager or `dotnet` cli.
+
+```powershell
+dotnet add package Correlate
+```
+
+For ASP.NET Core integration:
+
+```powershell
+dotnet add package Correlate.AspNetCore
+```
+
+---
+
+[![Build status](https://ci.appveyor.com/api/projects/status/rwfdg9d4i3g0qyga/branch/master?svg=true)](https://ci.appveyor.com/project/skwasjer/correlate)
+[![Tests](https://img.shields.io/appveyor/tests/skwasjer/Correlate/master.svg)](https://ci.appveyor.com/project/skwasjer/correlate/build/tests)
+
+| | | |
+|---|---|---|
+| `Correlate` | [![NuGet](https://img.shields.io/nuget/v/Correlate.svg)](https://www.nuget.org/packages/Correlate/) [![NuGet](https://img.shields.io/nuget/dt/Correlate.svg)](https://www.nuget.org/packages/Correlate/) | Core library, including a `DelegatingHandler` for `HttpClient`. |
+| `Correlate.Abstractions` | [![NuGet](https://img.shields.io/nuget/v/Correlate.Abstractions.svg)](https://www.nuget.org/packages/Correlate.Abstractions/) [![NuGet](https://img.shields.io/nuget/dt/Correlate.Abstractions.svg)](https://www.nuget.org/packages/Correlate.Abstractions/) | Abstractions library. |
+| `Correlate.AspNetCore` | [![NuGet](https://img.shields.io/nuget/v/Correlate.AspNetCore.svg)](https://www.nuget.org/packages/Correlate.AspNetCore/) [![NuGet](https://img.shields.io/nuget/dt/Correlate.AspNetCore.svg)](https://www.nuget.org/packages/Correlate.AspNetCore/) | ASP.NET Core middleware. |
+| `Correlate.DependencyInjection` | [![NuGet](https://img.shields.io/nuget/v/Correlate.DependencyInjection.svg)](https://www.nuget.org/packages/Correlate.DependencyInjection/) [![NuGet](https://img.shields.io/nuget/dt/Correlate.DependencyInjection.svg)](https://www.nuget.org/packages/Correlate.DependencyInjection/) | Extensions for registration in a `IServiceCollection` container. |
 
 ## Usage
 
-In a typical ASP.NET Core (MVC) application, register the middleware and required services. Optionally, if using `HttpClient` to call other services, use `HttpClientFactory` to attach a delegating handler to a `HttpClient`, automatically adding a correlation id to the outgoing request for cross service correlation.
+In a typical ASP.NET Core (MVC) application, register the middleware and required services to handle incoming requests with a correlation id, and to enrich the response with a relevant correlation id.
+
+When using `HttpClient` to call other services, you can use `HttpClientFactory` to attach a delegating handler to any `HttpClient` which will automatically add a correlation id header to the outgoing request for cross service correlation.
 
 ### Example ###
-
-For an MVC application, add the package:
-
-```
-dotnet add package Correlate.AspNetCore 
-```
 
 Configure your application:
 
@@ -43,7 +54,7 @@ public class Startup
             {
               // List of incoming headers possible. First that is set on given request is used and also returned in the response.
               "X-Correlation-ID",
-              "Correlation-ID"
+              "My-Correlation-ID"
             }
         );
 
@@ -65,20 +76,27 @@ public class Startup
 }
 ```
 
-> NOTE: This set of libraries is a work in progress.
+Using this setup, for any incoming request that contains a `X-Correlation-ID` or `My-Correlation-ID` header, the correlation id from that header will be used throughout the request pipeline. For any incoming request without either header, a unique correlation id is generated instead.
+
+Secondly, all responses will receive a matching response header.
+
+Thirdly, for all outbound HTTP calls that are sent via the `HttpClient` provided to `MyService` instances, a `X-Correlation-ID` request header is added.
+
+> In order to capture incoming requests with correlation ids as soon as possible, the middleware should be registered as the first middleware in the pipeline or at least near the top. Otherwise, you have middleware executing outside of the correlation context scope making them untrackable.
 
 ## Logging
 
-The Correlate middleware takes care of processing each incoming request for a correlation id. If no correlation is provided, one will be generated. Before the request continues down the pipeline, a log scope is created with a `CorrelationId` property, containing the correlation id.
+Before a request flows down the pipeline, a log scope is created with a `CorrelationId` property, containing the correlation id.
 
 Most popular log providers will be able to log the correlation id with minimal set up required.
 
-For example:
+Here's some providers that require no set up or custom code, only configuration:
 
-- Serilog: `new LoggerConfiguration().Enrich.FromLogContext()` https://github.com/serilog/serilog/wiki/Enrichment#the-logcontext
+- Serilog: `new LoggerConfiguration().Enrich.FromLogContext()`
+  https://github.com/serilog/serilog/wiki/Enrichment#the-logcontext  
 - NLog: https://github.com/NLog/NLog/wiki/EventProperties-Layout-Renderer
 
-## ICorrelationContextAccessor - Getting/setting the correlation id from anywhere
+## ICorrelationContextAccessor - Getting the correlation id from anywhere
 
 To access the correlation id anywhere in code, inject an instance of `ICorrelationContextAccessor` in your constructor. 
 
@@ -94,15 +112,11 @@ public class MyService
 }
 ```
 
-> Note: `correlationContextAccessor.CorrelationContext` will be null, when `MyService` is not scoped to a request. Thus, when used outside of ASP.NET (not using the middleware component), you are yourself responsible for creating the context using `ICorrelationContextFactory` or `CorrelationManager`.
-
-## ICorrelationContextFactory
-
-This factory creates the correlation context and then sets it in the `ICorrelationContextAccessor`. If you wish to use the Correlate framework in for example a backend worker task (outside of ASP.NET Core pipeline), you can use this factory to scope individual tasks each with their own correlation context.
+> Note: `correlationContextAccessor.CorrelationContext` can be null, when `MyService` is not scoped to a request. Thus, when used outside of ASP.NET (not using the middleware component), you should create the context using `ICorrelationContextFactory` or `CorrelationManager` for each unique subprocess.
 
 ## CorrelationManager
 
-For more advanced use cases and to simplify managing correlation contexts, a manager can be used instead that takes care of alot of the logic to create the context properly. This is especially useful when running background tasks that interact with external services.
+To simplify managing correlation contexts, the `CorrelationManager` can be used. It takes care of alot of the logic to create the context properly. This is especially useful when running background tasks or applications other than ASP.NET Core which need to interact with external services.
 
 ### Example
 
@@ -110,10 +124,12 @@ For more advanced use cases and to simplify managing correlation contexts, a man
 public class MyWorker
 {
     private readonly CorrelationManager _correlationManager;
+    private readonly MyService _myService;
 
-    public MyWorker(CorrelationManager correlationManager)
+    public MyWorker(CorrelationManager correlationManager, MyService myService)
     {
         _correlationManager = correlationManager;
+        _myService = myService;
     }
 
     public async Task RunAsync()
@@ -122,6 +138,7 @@ public class MyWorker
         {
             await _correlationManager.CorrelateAsync(async () => {
                 // Do work in a scoped correlation context with its own correlation id.
+                await myService.MakeHttpCallAsync();
             });
 
             await Task.Delay(5000);
@@ -130,11 +147,27 @@ public class MyWorker
 }
 ```
 
+In this example the `MakeHttpCallAsync()` call is executed in a scoped correlation context, for which a correlation id is automatically generated and attached to the outgoing request provided the `HttpClient` is set up with the delegating handler:
+
+```csharp
+services
+    .AddHttpClient<IMyService, MyService>()
+    .CorrelateRequests("X-Correlation-ID");
+```
+
+## Enabling Correlate
+
+Correlate depends on logging (`ILogger`) and/or tracing (`DiagnosticsListener`), in a sense that a correlation context will only be created when one of either is enabled. This is intentional, because it does not make much sense to have the overhead of Correlate - no matter how minute - when nothing is logged/traced.
+
+If the `IsEnabled()` method for both returns `false`, the `CorrelationManager` will simply execute the task without scoping it to a correlation context. This also means that `ICorrelationContextAccessor.CorrelationContext` will return `null`, since no context is created.
+
+For ASP.NET Core no additional setup is required, and Correlate will just be enabled (unless you explicitly disabled logging/tracing). When working outside of ASP.NET Core, make sure logging or tracing is enabled via configuration/code. This includes in unit tests.
+
 ## ICorrelationIdFactory
 
 By default, when generating a correlation id, the `GuidCorrelationIdFactory` will produce guid based correlation ids.
 
-As an alternative, there's also a `RequestIdentifierCorrelationIdFactory` which produces base32 encoded correlation ids. To use this instead, simply register it manually in the service container.
+As an alternative, there's also a `RequestIdentifierCorrelationIdFactory` which produces base32 encoded correlation ids. To use this or a custom implementation  instead, simply register it manually in the service container.
 
 ### Example
 ```csharp

--- a/src/Correlate.AspNetCore/AspNetCore/ILoggerExtensions.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/ILoggerExtensions.cs
@@ -59,7 +59,7 @@ namespace Correlate.AspNetCore
 
 					if (index == 2)
 					{
-						return new KeyValuePair<string, object>("CorrelationId", _correlationId);
+						return new KeyValuePair<string, object>(CorrelateConstants.CorrelationIdKey, _correlationId);
 					}
 
 					throw new ArgumentOutOfRangeException(nameof(index));

--- a/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateMiddleware.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateMiddleware.cs
@@ -41,11 +41,12 @@ namespace Correlate.AspNetCore.Middleware
 
 			if (_options.RequestHeaders == null || !_options.RequestHeaders.Any())
 			{
-				throw new ArgumentException("Configuration error, at least one request header should be specified.", nameof(options));
+				_acceptedRequestHeaders = ImmutableArray<string>.Empty;
 			}
-
-			// Ensure array never change during the lifetime of middleware.
-			_acceptedRequestHeaders = _options.RequestHeaders.ToImmutableArray();
+			else
+			{
+				_acceptedRequestHeaders = _options.RequestHeaders.ToImmutableArray();
+			}
 		}
 
 		/// <summary>

--- a/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
+++ b/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="[2.1.0,2.2.0]" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/Correlate.Core/Correlate.Core.csproj
+++ b/src/Correlate.Core/Correlate.Core.csproj
@@ -17,9 +17,9 @@
   <Import Project="..\Package.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[2.1.0,2.2.0]" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[2.1.0,2.2.0]" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[4.5.0,4.5.1]" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Correlate.Core/CorrelateConstants.cs
+++ b/src/Correlate.Core/CorrelateConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace Correlate
+{
+	internal static class CorrelateConstants
+	{
+		public const string CorrelationIdKey = "CorrelationId";
+	}
+}

--- a/src/Correlate.Core/CorrelationManager.cs
+++ b/src/Correlate.Core/CorrelationManager.cs
@@ -99,6 +99,16 @@ namespace Correlate
 			{
 				await correlatedTask().ConfigureAwait(false);
 			}
+			catch (Exception ex)
+			{
+				if (correlationContext?.CorrelationId != null && !ex.Data.Contains(CorrelateConstants.CorrelationIdKey))
+				{
+					// Because we're about to lose context scope, enrich exception with correlation id for reference by calling code.
+					ex.Data.Add(CorrelateConstants.CorrelationIdKey, correlationContext.CorrelationId);
+				}
+
+				throw;
+			}
 			finally
 			{
 				activity.Stop();

--- a/src/Correlate.Core/CorrelationManager.cs
+++ b/src/Correlate.Core/CorrelationManager.cs
@@ -90,7 +90,7 @@ namespace Correlate
 
 			try
 			{
-				await correlatedTask();
+				await correlatedTask().ConfigureAwait(false);
 			}
 			finally
 			{

--- a/src/Correlate.Core/Http/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Correlate.Core/Http/Extensions/HeaderDictionaryExtensions.cs
@@ -16,7 +16,7 @@ namespace Correlate.Http.Extensions
 
 			if (!acceptedHeaders.Any())
 			{
-				throw new ArgumentException("At least one header should be specified.", nameof(acceptedHeaders));
+				return new KeyValuePair<string, string>(CorrelationHttpHeaders.CorrelationId, null);
 			}
 
 			string correlationId = null;

--- a/src/Correlate.Core/ILoggerExtensions.cs
+++ b/src/Correlate.Core/ILoggerExtensions.cs
@@ -44,7 +44,7 @@ namespace Correlate
 				{
 					if (index == 0)
 					{
-						return new KeyValuePair<string, object>("CorrelationId", _correlationId);
+						return new KeyValuePair<string, object>(CorrelateConstants.CorrelationIdKey, _correlationId);
 					}
 
 					throw new ArgumentOutOfRangeException(nameof(index));

--- a/src/Correlate.Core/InternalsVisibleTo.cs
+++ b/src/Correlate.Core/InternalsVisibleTo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Correlate.AspNetCore")]
 [assembly: InternalsVisibleTo("Correlate.Core.Tests")]
+[assembly: InternalsVisibleTo("Correlate.AspNetCore")]
+[assembly: InternalsVisibleTo("Correlate.AspNetCore.Tests")]

--- a/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
+++ b/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="[2.1.0,2.2.0]" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/Middleware/CorrelateMiddlewareTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/Middleware/CorrelateMiddlewareTests.cs
@@ -100,6 +100,23 @@ namespace Correlate.AspNetCore.Middleware
 		}
 
 		[Fact]
+		public async Task Given_no_headers_are_defined_when_executing_request_the_response_should_contain_default_header()
+		{
+			_options.RequestHeaders = new string[0];
+
+			// Act
+			HttpClient client = _factory.CreateClient();
+			HttpResponseMessage response = await client.GetAsync("");
+
+			// Assert
+			response.Headers
+				.Should().ContainCorrelationId()
+				.WhichValue.Should()
+				.ContainSingle()
+				.Which.Should().NotBeEmpty();
+		}
+
+		[Fact]
 		public async Task Given_response_is_disabled_when_executing_request_the_response_should_not_contain_correlation_id()
 		{
 			_options.IncludeInResponse = false;

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/Middleware/CorrelateMiddlewareTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/Middleware/CorrelateMiddlewareTests.cs
@@ -157,7 +157,7 @@ namespace Correlate.AspNetCore.Middleware
 					.ToList()
 					.ForEach(le => le.Properties
 						.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
-						.Should().ContainKey("CorrelationId")
+						.Should().ContainKey(CorrelateConstants.CorrelationIdKey)
 						.WhichValue.Should().BeOfType<ScalarValue>()
 						.Which.Value.Should().BeNull());
 				logEvents
@@ -166,7 +166,7 @@ namespace Correlate.AspNetCore.Middleware
 					.ToList()
 					.ForEach(le => le.Properties
 						.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
-						.Should().ContainKey("CorrelationId")
+						.Should().ContainKey(CorrelateConstants.CorrelationIdKey)
 						.WhichValue.Should().BeOfType<ScalarValue>()
 						.Which.Value.Should().Be(correlationId));
 			}

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/Middleware/HttpRequestActivityTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/Middleware/HttpRequestActivityTests.cs
@@ -63,7 +63,7 @@ namespace Correlate.AspNetCore.Middleware
 		[Fact]
 		public async Task When_context_has_started_should_create_logScope_with_correlationId()
 		{
-			const string expectedLogProperty = "CorrelationId";
+			const string expectedLogProperty = CorrelateConstants.CorrelationIdKey;
 
 			// Act
 			using (TestCorrelator.CreateContext())

--- a/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
+++ b/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>Correlate</RootNamespace>

--- a/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
+++ b/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>Correlate</RootNamespace>

--- a/test/Correlate.Core.Tests/CorrelationManagerTests.cs
+++ b/test/Correlate.Core.Tests/CorrelationManagerTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections;
+using System.Threading.Tasks;
+using Correlate.Testing;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Correlate
+{
+	public class CorrelationManagerTests
+	{
+		private readonly CorrelationContextAccessor _correlationContextAccessor;
+		private readonly CorrelationManager _sut;
+		private readonly Mock<ICorrelationIdFactory> _correlationIdFactoryMock;
+		private const string GeneratedCorrelationId = "generated-correlation-id";
+
+		public CorrelationManagerTests()
+		{
+			_correlationContextAccessor = new CorrelationContextAccessor();
+
+			_correlationIdFactoryMock = new Mock<ICorrelationIdFactory>();
+			_correlationIdFactoryMock
+				.Setup(m => m.Create())
+				.Returns(() => GeneratedCorrelationId)
+				.Verifiable();
+
+			_sut = new CorrelationManager(
+				new CorrelationContextFactory(_correlationContextAccessor),
+				_correlationIdFactoryMock.Object,
+				new TestLogger<CorrelationManager>()
+			);
+		}
+
+		[Fact]
+		public async Task Given_a_task_should_run_task_inside_correlated_context()
+		{
+			// Pre-assert
+			_correlationContextAccessor.CorrelationContext.Should().BeNull();
+
+			// Act
+			await _sut.CorrelateAsync(() =>
+			{
+				// Inline assert
+				_correlationContextAccessor.CorrelationContext.Should().NotBeNull();
+				return Task.CompletedTask;
+			});
+
+			// Post-assert
+			_correlationContextAccessor.CorrelationContext.Should().BeNull();
+		}
+
+		[Fact]
+		public async Task When_running_correlated_task_without_correlation_id_should_use_generate_one()
+		{
+			// Act
+			await _sut.CorrelateAsync(() =>
+			{
+				// Inline assert
+				_correlationContextAccessor.CorrelationContext.CorrelationId.Should().Be(GeneratedCorrelationId);
+				return Task.CompletedTask;
+			});
+
+			_correlationIdFactoryMock.Verify();
+		}
+
+		[Fact]
+		public async Task When_running_correlated_task_with_correlation_id_should_use_it()
+		{
+			const string correlationId = "my-correlation-id";
+
+			// Act
+			await _sut.CorrelateAsync(correlationId, () =>
+			{
+				// Inline assert
+				_correlationContextAccessor.CorrelationContext.CorrelationId.Should().Be(correlationId);
+				return Task.CompletedTask;
+			});
+
+			_correlationIdFactoryMock.Verify(m => m.Create(), Times.Never);
+		}
+
+		[Fact]
+		public void When_not_providing_task_when_starting_correlation_should_throw()
+		{
+			// Act
+			Func<Task> act = () => _sut.CorrelateAsync(null, null);
+
+			// Assert
+			act.Should()
+				.Throw<ArgumentNullException>()
+				.Which.ParamName.Should()
+				.Be("correlatedTask");
+		}
+	}
+}

--- a/test/Correlate.Core.Tests/CorrelationManagerTests.cs
+++ b/test/Correlate.Core.Tests/CorrelationManagerTests.cs
@@ -92,5 +92,33 @@ namespace Correlate
 				.Which.ParamName.Should()
 				.Be("correlatedTask");
 		}
+
+		[Fact]
+		public void When_provided_task_throws_should_not_wrap_exception()
+		{
+			var exception = new Exception();
+			Task ThrowingTask() => throw exception;
+
+			// Act
+			Func<Task> act = () => _sut.CorrelateAsync(null, ThrowingTask);
+
+			// Assert
+			act.Should().Throw<Exception>().Which.Should().Be(exception);
+		}
+
+		[Fact]
+		public void When_provided_task_throws_should_enrich_exception_with_correlationId()
+		{
+			var exception = new Exception();
+			Task ThrowingTask() => throw exception;
+
+			// Act
+			Func<Task> act = () => _sut.CorrelateAsync(null, ThrowingTask);
+
+			// Assert
+			IDictionary exceptionData = act.Should().Throw<Exception>().Which.Data;
+			exceptionData.Keys.Should().Contain(CorrelateConstants.CorrelationIdKey);
+			exceptionData[CorrelateConstants.CorrelationIdKey].Should().Be(GeneratedCorrelationId);
+		}
 	}
 }

--- a/test/Correlate.Core.Tests/Http/Extensions/HeaderDictionaryExtensionsTests.cs
+++ b/test/Correlate.Core.Tests/Http/Extensions/HeaderDictionaryExtensionsTests.cs
@@ -46,15 +46,14 @@ namespace Correlate.Http.Extensions
 		[Fact]
 		public void When_using_empty_accepted_headers_should_throw()
 		{
+			_sut.Add(CorrelationHttpHeaders.CorrelationId, new StringValues(CorrelationId));
+			var expectedHeader = new KeyValuePair<string, string>(CorrelationHttpHeaders.CorrelationId, null);
+
 			// Act
-			Action act = () => _sut.GetCorrelationIdHeader(new string[0]);
+			KeyValuePair<string, string> header = _sut.GetCorrelationIdHeader(new string[0]);
 
 			// Assert
-			act.Should()
-				.Throw<ArgumentException>()
-				.WithMessage("At least one header should be specified.*")
-				.Which.ParamName.Should()
-				.Be("acceptedHeaders");
+			header.Should().BeEquivalentTo(expectedHeader, "it should not take correlation id from header dictionary but still return header key");
 		}
 
 		[Fact]

--- a/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
+++ b/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>Correlate.DependencyInjection</RootNamespace>

--- a/test/Correlate.Testing/Correlate.Testing.csproj
+++ b/test/Correlate.Testing/Correlate.Testing.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[2.1.0,2.2.0]" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[2.1.0,2.2.0]" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
   </ItemGroup>

--- a/test/Correlate.Testing/LoggingExtensions.cs
+++ b/test/Correlate.Testing/LoggingExtensions.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 
 namespace Correlate.Testing
 {
@@ -9,12 +7,12 @@ namespace Correlate.Testing
 	{
 		public static IServiceCollection ForceEnableLogging(this IServiceCollection services)
 		{
-			return services.AddLogging(logging => logging.AddProvider(new DummyProvider()));
+			return services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider()));
 		}
 
-		private class DummyProvider : ILoggerProvider
+		private class TestLoggerProvider : ILoggerProvider
 		{
-			private DummyLogger _dummyLogger;
+			private TestLogger _testLogger;
 
 			public void Dispose()
 			{
@@ -22,24 +20,7 @@ namespace Correlate.Testing
 
 			public ILogger CreateLogger(string categoryName)
 			{
-				return _dummyLogger ?? (_dummyLogger = new DummyLogger());
-			}
-		}
-
-		private class DummyLogger : ILogger
-		{
-			public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-			{
-			}
-
-			public bool IsEnabled(LogLevel logLevel)
-			{
-				return true;
-			}
-
-			public IDisposable BeginScope<TState>(TState state)
-			{
-				return NullScope.Instance;
+				return _testLogger ?? (_testLogger = new TestLogger());
 			}
 		}
 	}

--- a/test/Correlate.Testing/TestLogger.cs
+++ b/test/Correlate.Testing/TestLogger.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions.Internal;
+
+namespace Correlate.Testing
+{
+	public class TestLogger<T> : TestLogger, ILogger<T>
+	{
+		public TestLogger(bool isEnabled = true)
+			: base(isEnabled)
+		{
+		}
+	}
+
+	public class TestLogger : ILogger
+	{
+		private readonly bool _isEnabled;
+
+		public TestLogger(bool isEnabled = true)
+		{
+			_isEnabled = isEnabled;
+		}
+
+		public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+		{
+		}
+
+		public bool IsEnabled(LogLevel logLevel)
+		{
+			return _isEnabled;
+		}
+
+		public IDisposable BeginScope<TState>(TState state)
+		{
+			return NullScope.Instance;
+		}
+	}
+}


### PR DESCRIPTION
- Fix potential deadlocks for async/awaited call
- Allow no request headers, effectively disabling incoming correlation id
- Add ability to handle exceptions via delegate while still in correlation context scope