### PR TITLE
.NET Standard 2.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ dotnet add package Correlate.AspNetCore
 
 [![Build status](https://ci.appveyor.com/api/projects/status/rwfdg9d4i3g0qyga/branch/master?svg=true)](https://ci.appveyor.com/project/skwasjer/correlate)
 [![Tests](https://img.shields.io/appveyor/tests/skwasjer/Correlate/master.svg)](https://ci.appveyor.com/project/skwasjer/correlate/build/tests)
+[![codecov](https://codecov.io/gh/skwasjer/Correlate/branch/master/graph/badge.svg)](https://codecov.io/gh/skwasjer/MockHttp)
 
 | | | |
 |---|---|---|

--- a/src/Correlate.Abstractions/Correlate.Abstractions.csproj
+++ b/src/Correlate.Abstractions/Correlate.Abstractions.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard1.0;net46</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Correlate.Abstractions/CorrelationContext.cs
+++ b/src/Correlate.Abstractions/CorrelationContext.cs
@@ -8,6 +8,6 @@
 		/// <summary>
 		/// Gets or sets the correlation id.
 		/// </summary>
-		public string CorrelationId { get; set; }
+		public string? CorrelationId { get; set; }
 	}
 }

--- a/src/Correlate.Abstractions/ExceptionContext.cs
+++ b/src/Correlate.Abstractions/ExceptionContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Correlate
 {
@@ -33,12 +34,14 @@ namespace Correlate
 	/// </summary>
 	public class ExceptionContext<T> : ExceptionContext
 	{
+		// ReSharper disable once RedundantDefaultMemberInitializer
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-		private T _result;
+		private T _result = default!;
 
 		/// <summary>
 		/// Gets or sets the result value to return. This is only 
 		/// </summary>
+		[AllowNull]
 		public T Result
 		{
 			get

--- a/src/Correlate.Abstractions/ExceptionContext.cs
+++ b/src/Correlate.Abstractions/ExceptionContext.cs
@@ -9,19 +9,21 @@ namespace Correlate
 	/// </summary>
 	public class ExceptionContext
 	{
-		internal ExceptionContext()
+		internal ExceptionContext(CorrelationContext correlationContext, Exception exception)
 		{
+			CorrelationContext = correlationContext;
+			Exception = exception;
 		}
 
 		/// <summary>
 		/// Gets the correlation context
 		/// </summary>
-		public CorrelationContext CorrelationContext { get; internal set; }
+		public CorrelationContext CorrelationContext { get; }
 
 		/// <summary>
 		/// Gets the exception that occurred.
 		/// </summary>
-		public Exception Exception { get; internal set; }
+		public Exception Exception { get; }
 
 		/// <summary>
 		/// Gets or sets whether the exception is considered handled.
@@ -37,6 +39,11 @@ namespace Correlate
 		// ReSharper disable once RedundantDefaultMemberInitializer
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private T _result = default!;
+
+		internal ExceptionContext(CorrelationContext correlationContext, Exception exception)
+			: base(correlationContext, exception)
+		{
+		}
 
 		/// <summary>
 		/// Gets or sets the result value to return. This is only 

--- a/src/Correlate.Abstractions/IActivity.cs
+++ b/src/Correlate.Abstractions/IActivity.cs
@@ -15,6 +15,8 @@
 		/// <summary>
 		/// Signals the activity is complete.
 		/// </summary>
+#pragma warning disable CA1716
 		void Stop();
+#pragma warning restore CA1716
 	}
 }

--- a/src/Correlate.Abstractions/IAsyncCorrelationManager.cs
+++ b/src/Correlate.Abstractions/IAsyncCorrelationManager.cs
@@ -18,7 +18,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the task simply executed as it normally would.
 		/// </remarks>
-		Task CorrelateAsync(string correlationId, Func<Task> correlatedTask, OnException onException);
+		Task CorrelateAsync(string? correlationId, Func<Task> correlatedTask, OnException? onException);
 
 		/// <summary>
 		/// Executes the <paramref name="correlatedTask"/> with its own <see cref="CorrelationContext"/>.
@@ -31,6 +31,6 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the task simply executed as it normally would.
 		/// </remarks>
-		Task<T> CorrelateAsync<T>(string correlationId, Func<Task<T>> correlatedTask, OnException<T> onException);
+		Task<T> CorrelateAsync<T>(string? correlationId, Func<Task<T>> correlatedTask, OnException<T>? onException);
 	}
 }

--- a/src/Correlate.Abstractions/ICorrelationContextAccessor.cs
+++ b/src/Correlate.Abstractions/ICorrelationContextAccessor.cs
@@ -8,6 +8,6 @@
 		/// <summary>
 		/// Gets or sets <see cref="CorrelationContext"/>.
 		/// </summary>
-		CorrelationContext CorrelationContext { get; set; }
+		CorrelationContext? CorrelationContext { get; set; }
 	}
 }

--- a/src/Correlate.Abstractions/ICorrelationManager.cs
+++ b/src/Correlate.Abstractions/ICorrelationManager.cs
@@ -16,7 +16,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the action simply executed as it normally would.
 		/// </remarks>
-		void Correlate(string correlationId, Action correlatedAction, OnException onException);
+		void Correlate(string? correlationId, Action correlatedAction, OnException? onException);
 
 		/// <summary>
 		/// Executes the <paramref name="correlatedFunc"/> with its own <see cref="CorrelationContext"/>.
@@ -29,6 +29,6 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the action simply executed as it normally would.
 		/// </remarks>
-		T Correlate<T>(string correlationId, Func<T> correlatedFunc, OnException<T> onException);
+		T Correlate<T>(string? correlationId, Func<T> correlatedFunc, OnException<T>? onException);
 	}
 }

--- a/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateMiddleware.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateMiddleware.cs
@@ -60,6 +60,7 @@ namespace Correlate.AspNetCore.Middleware
 		/// <returns>An awaitable to wait for to complete the request.</returns>
 		public Task Invoke(HttpContext httpContext)
 		{
+			// ReSharper disable once UseDeconstruction - not supported in .NET46/.NETS
 			KeyValuePair<string, string> requestHeader = httpContext.Request.Headers.GetCorrelationIdHeader(_acceptedRequestHeaders);
 			if (requestHeader.Value != null)
 			{
@@ -78,7 +79,7 @@ namespace Correlate.AspNetCore.Middleware
 						{
 							correlatedHttpRequest.Stop();
 							return t;
-						})
+						}, TaskScheduler.Current)
 						.Unwrap();
 				});
 		}

--- a/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateMiddleware.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateMiddleware.cs
@@ -60,6 +60,11 @@ namespace Correlate.AspNetCore.Middleware
 		/// <returns>An awaitable to wait for to complete the request.</returns>
 		public Task Invoke(HttpContext httpContext)
 		{
+			if (httpContext is null)
+			{
+				throw new ArgumentNullException(nameof(httpContext));
+			}
+
 			// ReSharper disable once UseDeconstruction - not supported in .NET46/.NETS
 			KeyValuePair<string, string> requestHeader = httpContext.Request.Headers.GetCorrelationIdHeader(_acceptedRequestHeaders);
 			if (requestHeader.Value != null)

--- a/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateMiddleware.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateMiddleware.cs
@@ -66,13 +66,13 @@ namespace Correlate.AspNetCore.Middleware
 			}
 
 			// ReSharper disable once UseDeconstruction - not supported in .NET46/.NETS
-			KeyValuePair<string, string> requestHeader = httpContext.Request.Headers.GetCorrelationIdHeader(_acceptedRequestHeaders);
+			KeyValuePair<string, string?> requestHeader = httpContext.Request.Headers.GetCorrelationIdHeader(_acceptedRequestHeaders);
 			if (requestHeader.Value != null)
 			{
 				_logger.LogTrace("Request header '{HeaderName}' found with correlation id '{CorrelationId}'.", requestHeader.Key, requestHeader.Value);
 			}
 
-			string responseHeaderName = _options.IncludeInResponse ? requestHeader.Key : null;
+			string? responseHeaderName = _options.IncludeInResponse ? requestHeader.Key : null;
 			var correlatedHttpRequest = new HttpRequestActivity(_logger, httpContext, responseHeaderName);
 			return _asyncCorrelationManager.CorrelateAsync(
 				requestHeader.Value,

--- a/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateOptions.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/Middleware/CorrelateOptions.cs
@@ -13,9 +13,11 @@ namespace Correlate.AspNetCore.Middleware
 		/// <remarks>
 		/// The first matching header will be used.
 		/// </remarks>
+#pragma warning disable CA1819 // TODO: in next major release change to IEnumerable<>/ICollection<>.
 		public string[] RequestHeaders { get; set; } = {
 			CorrelationHttpHeaders.CorrelationId
 		};
+#pragma warning restore CA1819
 
 		/// <summary>
 		/// Gets or sets whether to include the correlation id in the response.

--- a/src/Correlate.AspNetCore/AspNetCore/Middleware/HttpRequestActivity.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/Middleware/HttpRequestActivity.cs
@@ -37,7 +37,9 @@ namespace Correlate.AspNetCore.Middleware
 			}
 		}
 
+#pragma warning disable CA1822
 		public void Stop()
+#pragma warning restore CA1822
 		{
 		}
 	}

--- a/src/Correlate.AspNetCore/AspNetCore/Middleware/HttpRequestActivity.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/Middleware/HttpRequestActivity.cs
@@ -8,10 +8,10 @@ namespace Correlate.AspNetCore.Middleware
 	{
 		private readonly HttpContext _httpContext;
 		private readonly ILogger _logger;
-		private readonly string _responseHeaderName;
+		private readonly string? _responseHeaderName;
 		private readonly bool _includeInResponse;
 
-		internal HttpRequestActivity(ILogger logger, HttpContext httpContext, string responseHeaderName)
+		internal HttpRequestActivity(ILogger logger, HttpContext httpContext, string? responseHeaderName)
 		{
 			_logger = logger;
 			_httpContext = httpContext;
@@ -19,7 +19,7 @@ namespace Correlate.AspNetCore.Middleware
 			_includeInResponse = !string.IsNullOrWhiteSpace(responseHeaderName);
 		}
 
-		public void Start(CorrelationContext correlationContext)
+		public void Start(CorrelationContext? correlationContext)
 		{
 			if (_includeInResponse && correlationContext != null)
 			{

--- a/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
+++ b/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
+++ b/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
@@ -13,7 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/Correlate.AspNetCore/GlobalSuppressions.cs
+++ b/src/Correlate.AspNetCore/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Will change later.")]

--- a/src/Correlate.AspNetCore/RequestIdentifierCorrelationIdFactory.cs
+++ b/src/Correlate.AspNetCore/RequestIdentifierCorrelationIdFactory.cs
@@ -7,7 +7,7 @@ namespace Correlate
 	/// </summary>
 	public class RequestIdentifierCorrelationIdFactory : ICorrelationIdFactory
 	{
-		private readonly IHttpRequestIdentifierFeature _httpRequestIdentifierFeature;
+		private readonly HttpRequestIdentifierFeature _httpRequestIdentifierFeature;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="RequestIdentifierCorrelationIdFactory"/> class.
@@ -22,7 +22,7 @@ namespace Correlate
 		{
 			// Set to null, so the next 'get' will produce a new id.
 			_httpRequestIdentifierFeature.TraceIdentifier = null;
-			return _httpRequestIdentifierFeature.TraceIdentifier;
+			return _httpRequestIdentifierFeature.TraceIdentifier!;
 		}
 	}
 }

--- a/src/Correlate.Core/Correlate.Core.csproj
+++ b/src/Correlate.Core/Correlate.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3;net46</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Correlate.Core/Correlate.Core.csproj
+++ b/src/Correlate.Core/Correlate.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3;net46</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
@@ -13,6 +13,12 @@
     <PackageTags>correlationid, correlation, correlate, causation, aspnet, middleware, httpclient, httpclientfactory</PackageTags>
     <AssemblyName>Correlate</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" />
+  </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />

--- a/src/Correlate.Core/CorrelationContextAccessor.cs
+++ b/src/Correlate.Core/CorrelationContextAccessor.cs
@@ -10,7 +10,7 @@ namespace Correlate
 		private static readonly AsyncLocal<CorrelationContextHolder> CurrentContext = new AsyncLocal<CorrelationContextHolder>();
 
 		/// <inheritdoc />
-		public CorrelationContext CorrelationContext
+		public CorrelationContext? CorrelationContext
 		{
 			get => CurrentContext.Value?.Context;
 			set
@@ -47,8 +47,8 @@ namespace Correlate
 
 		private class CorrelationContextHolder
 		{
-			public CorrelationContext Context { get; set; }
-			public CorrelationContextHolder ParentContext { get; set; }
+			public CorrelationContext? Context { get; set; }
+			public CorrelationContextHolder? ParentContext { get; set; }
 		}
 	}
 }

--- a/src/Correlate.Core/CorrelationContextFactory.cs
+++ b/src/Correlate.Core/CorrelationContextFactory.cs
@@ -7,7 +7,7 @@ namespace Correlate
 	/// </summary>
 	public class CorrelationContextFactory : ICorrelationContextFactory
 	{
-		private readonly ICorrelationContextAccessor _correlationContextAccessor;
+		private readonly ICorrelationContextAccessor? _correlationContextAccessor;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="CorrelationContextFactory"/> class.

--- a/src/Correlate.Core/CorrelationManager.cs
+++ b/src/Correlate.Core/CorrelationManager.cs
@@ -151,7 +151,7 @@ namespace Correlate
 			return ExecuteAsync(
 				correlationId,
 				correlatedTask,
-				onException == null ? (OnException?)null: context => onException!((ExceptionContext<T>)context)
+				onException == null ? (OnException?)null : context => onException!((ExceptionContext<T>)context)
 			);
 		}
 
@@ -265,9 +265,9 @@ namespace Correlate
 				bool hasResultValue = typeof(T) != typeof(Void);
 
 				// Allow caller to handle exception inline before losing context scope.
-				ExceptionContext exceptionContext = hasResultValue ? new ExceptionContext<T>() : new ExceptionContext();
-				exceptionContext.Exception = ex;
-				exceptionContext.CorrelationContext = correlationContext;
+				ExceptionContext exceptionContext = hasResultValue
+					? new ExceptionContext<T>(correlationContext, ex)
+					: new ExceptionContext(correlationContext, ex);
 
 				onException(exceptionContext);
 				if (exceptionContext.IsExceptionHandled)

--- a/src/Correlate.Core/CorrelationManager.cs
+++ b/src/Correlate.Core/CorrelationManager.cs
@@ -151,7 +151,7 @@ namespace Correlate
 			return ExecuteAsync(
 				correlationId,
 				correlatedTask,
-				context => onException((ExceptionContext<T>)context)
+				onException == null ? (OnException?)null: context => onException!((ExceptionContext<T>)context)
 			);
 		}
 
@@ -217,7 +217,11 @@ namespace Correlate
 				throw new ArgumentNullException(nameof(correlatedFunc));
 			}
 
-			return Execute(correlationId, correlatedFunc, context => onException((ExceptionContext<T>)context));
+			return Execute(
+				correlationId,
+				correlatedFunc,
+				onException == null ? (OnException?)null : context => onException!((ExceptionContext<T>)context)
+			);
 		}
 
 		private T Execute<T>(string? correlationId, Func<T> correlatedFunc, OnException? onException)

--- a/src/Correlate.Core/CorrelationManager.cs
+++ b/src/Correlate.Core/CorrelationManager.cs
@@ -12,9 +12,9 @@ namespace Correlate
 	{
 		private readonly ICorrelationContextFactory _correlationContextFactory;
 		private readonly ICorrelationIdFactory _correlationIdFactory;
-		private readonly ICorrelationContextAccessor _correlationContextAccessor;
+		private readonly ICorrelationContextAccessor? _correlationContextAccessor;
 		private readonly ILogger _logger;
-		private readonly DiagnosticListener _diagnosticListener;
+		private readonly DiagnosticListener? _diagnosticListener;
 
 		private class Void
 		{
@@ -112,7 +112,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the task simply executed as it normally would.
 		/// </remarks>
-		public Task CorrelateAsync(string correlationId, Func<Task> correlatedTask, OnException onException)
+		public Task CorrelateAsync(string? correlationId, Func<Task> correlatedTask, OnException? onException)
 		{
 			if (correlatedTask == null)
 			{
@@ -141,7 +141,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the task simply executed as it normally would.
 		/// </remarks>
-		public Task<T> CorrelateAsync<T>(string correlationId, Func<Task<T>> correlatedTask, OnException<T> onException)
+		public Task<T> CorrelateAsync<T>(string? correlationId, Func<Task<T>> correlatedTask, OnException<T>? onException)
 		{
 			if (correlatedTask == null)
 			{
@@ -155,7 +155,7 @@ namespace Correlate
 			);
 		}
 
-		private async Task<T> ExecuteAsync<T>(string correlationId, Func<Task<T>> correlatedTask, OnException onException)
+		private async Task<T> ExecuteAsync<T>(string? correlationId, Func<Task<T>> correlatedTask, OnException? onException)
 		{
 			IActivity activity = CreateActivity();
 			CorrelationContext correlationContext = StartActivity(correlationId, activity);
@@ -173,7 +173,7 @@ namespace Correlate
 				activity.Stop();
 			}
 		}
-		
+
 		/// <summary>
 		/// Executes the <paramref name="correlatedAction"/> with its own <see cref="CorrelationContext"/>.
 		/// </summary>
@@ -183,7 +183,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the action simply executed as it normally would.
 		/// </remarks>
-		public void Correlate(string correlationId, Action correlatedAction, OnException onException)
+		public void Correlate(string? correlationId, Action correlatedAction, OnException? onException)
 		{
 			if (correlatedAction == null)
 			{
@@ -210,7 +210,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the action simply executed as it normally would.
 		/// </remarks>
-		public T Correlate<T>(string correlationId, Func<T> correlatedFunc, OnException<T> onException)
+		public T Correlate<T>(string? correlationId, Func<T> correlatedFunc, OnException<T>? onException)
 		{
 			if (correlatedFunc == null)
 			{
@@ -220,7 +220,7 @@ namespace Correlate
 			return Execute(correlationId, correlatedFunc, context => onException((ExceptionContext<T>)context));
 		}
 
-		private T Execute<T>(string correlationId, Func<T> correlatedFunc, OnException onException)
+		private T Execute<T>(string? correlationId, Func<T> correlatedFunc, OnException? onException)
 		{
 			IActivity activity = CreateActivity();
 			CorrelationContext correlationContext = StartActivity(correlationId, activity);
@@ -248,7 +248,7 @@ namespace Correlate
 			return new RootActivity(_correlationContextFactory, _logger, _diagnosticListener);
 		}
 
-		private static bool HandlesException<T>(OnException onException, CorrelationContext correlationContext, Exception ex, out T result)
+		private static bool HandlesException<T>(OnException? onException, CorrelationContext? correlationContext, Exception ex, out T result)
 		{
 			if (correlationContext != null && !ex.Data.Contains(CorrelateConstants.CorrelationIdKey))
 			{
@@ -270,16 +270,16 @@ namespace Correlate
 				{
 					result = hasResultValue
 						? ((ExceptionContext<T>)exceptionContext).Result
-						: default(T);
+						: default!;
 					return true;
 				}
 			}
 
-			result = default(T);
+			result = default!;
 			return false;
 		}
 
-		private CorrelationContext StartActivity(string correlationId, IActivity activity)
+		private CorrelationContext StartActivity(string? correlationId, IActivity activity)
 		{
 			return activity.Start(correlationId ?? _correlationContextAccessor?.CorrelationContext?.CorrelationId ?? _correlationIdFactory.Create());
 		}

--- a/src/Correlate.Core/CorrelationManager.cs
+++ b/src/Correlate.Core/CorrelationManager.cs
@@ -252,9 +252,9 @@ namespace Correlate
 			return new RootActivity(_correlationContextFactory, _logger, _diagnosticListener);
 		}
 
-		private static bool HandlesException<T>(OnException? onException, CorrelationContext? correlationContext, Exception ex, out T result)
+		private static bool HandlesException<T>(OnException? onException, CorrelationContext correlationContext, Exception ex, out T result)
 		{
-			if (correlationContext != null && !ex.Data.Contains(CorrelateConstants.CorrelationIdKey))
+			if (!ex.Data.Contains(CorrelateConstants.CorrelationIdKey))
 			{
 				// Because we're about to lose context scope, enrich exception with correlation id for reference by calling code.
 				ex.Data.Add(CorrelateConstants.CorrelationIdKey, correlationContext.CorrelationId);

--- a/src/Correlate.Core/Extensions/AsyncCorrelationManagerExtensions.cs
+++ b/src/Correlate.Core/Extensions/AsyncCorrelationManagerExtensions.cs
@@ -35,6 +35,11 @@ namespace Correlate
 		/// </remarks>
 		public static Task CorrelateAsync(this IAsyncCorrelationManager asyncCorrelationManager, Func<Task> correlatedTask, OnException onException)
 		{
+			if (asyncCorrelationManager is null)
+			{
+				throw new ArgumentNullException(nameof(asyncCorrelationManager));
+			}
+
 			return asyncCorrelationManager.CorrelateAsync(null, correlatedTask, onException);
 		}
 
@@ -50,6 +55,11 @@ namespace Correlate
 		/// </remarks>
 		public static Task CorrelateAsync(this IAsyncCorrelationManager asyncCorrelationManager, string correlationId, Func<Task> correlatedTask)
 		{
+			if (asyncCorrelationManager is null)
+			{
+				throw new ArgumentNullException(nameof(asyncCorrelationManager));
+			}
+
 			return asyncCorrelationManager.CorrelateAsync(correlationId, correlatedTask, null);
 		}
 
@@ -81,6 +91,11 @@ namespace Correlate
 		/// </remarks>
 		public static Task<T> CorrelateAsync<T>(this IAsyncCorrelationManager asyncCorrelationManager, Func<Task<T>> correlatedTask, OnException<T> onException)
 		{
+			if (asyncCorrelationManager is null)
+			{
+				throw new ArgumentNullException(nameof(asyncCorrelationManager));
+			}
+
 			return asyncCorrelationManager.CorrelateAsync(null, correlatedTask, onException);
 		}
 
@@ -97,6 +112,11 @@ namespace Correlate
 		/// </remarks>
 		public static Task<T> CorrelateAsync<T>(this IAsyncCorrelationManager asyncCorrelationManager, string correlationId, Func<Task<T>> correlatedTask)
 		{
+			if (asyncCorrelationManager is null)
+			{
+				throw new ArgumentNullException(nameof(asyncCorrelationManager));
+			}
+
 			return asyncCorrelationManager.CorrelateAsync(correlationId, correlatedTask, null);
 		}
 	}

--- a/src/Correlate.Core/Extensions/AsyncCorrelationManagerExtensions.cs
+++ b/src/Correlate.Core/Extensions/AsyncCorrelationManagerExtensions.cs
@@ -33,7 +33,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the task simply executed as it normally would.
 		/// </remarks>
-		public static Task CorrelateAsync(this IAsyncCorrelationManager asyncCorrelationManager, Func<Task> correlatedTask, OnException onException)
+		public static Task CorrelateAsync(this IAsyncCorrelationManager asyncCorrelationManager, Func<Task> correlatedTask, OnException? onException)
 		{
 			if (asyncCorrelationManager is null)
 			{
@@ -53,7 +53,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the task simply executed as it normally would.
 		/// </remarks>
-		public static Task CorrelateAsync(this IAsyncCorrelationManager asyncCorrelationManager, string correlationId, Func<Task> correlatedTask)
+		public static Task CorrelateAsync(this IAsyncCorrelationManager asyncCorrelationManager, string? correlationId, Func<Task> correlatedTask)
 		{
 			if (asyncCorrelationManager is null)
 			{
@@ -89,7 +89,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the task simply executed as it normally would.
 		/// </remarks>
-		public static Task<T> CorrelateAsync<T>(this IAsyncCorrelationManager asyncCorrelationManager, Func<Task<T>> correlatedTask, OnException<T> onException)
+		public static Task<T> CorrelateAsync<T>(this IAsyncCorrelationManager asyncCorrelationManager, Func<Task<T>> correlatedTask, OnException<T>? onException)
 		{
 			if (asyncCorrelationManager is null)
 			{
@@ -110,7 +110,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the task simply executed as it normally would.
 		/// </remarks>
-		public static Task<T> CorrelateAsync<T>(this IAsyncCorrelationManager asyncCorrelationManager, string correlationId, Func<Task<T>> correlatedTask)
+		public static Task<T> CorrelateAsync<T>(this IAsyncCorrelationManager asyncCorrelationManager, string? correlationId, Func<Task<T>> correlatedTask)
 		{
 			if (asyncCorrelationManager is null)
 			{

--- a/src/Correlate.Core/Extensions/CorrelationManagerExtensions.cs
+++ b/src/Correlate.Core/Extensions/CorrelationManagerExtensions.cs
@@ -32,6 +32,11 @@ namespace Correlate
 		/// </remarks>
 		public static void Correlate(this ICorrelationManager correlationManager, Action correlatedAction, OnException onException)
 		{
+			if (correlationManager is null)
+			{
+				throw new ArgumentNullException(nameof(correlationManager));
+			}
+
 			correlationManager.Correlate(null, correlatedAction, onException);
 		}
 
@@ -46,6 +51,11 @@ namespace Correlate
 		/// </remarks>
 		public static void Correlate(this ICorrelationManager correlationManager, string correlationId, Action correlatedAction)
 		{
+			if (correlationManager is null)
+			{
+				throw new ArgumentNullException(nameof(correlationManager));
+			}
+
 			correlationManager.Correlate(correlationId, correlatedAction, null);
 		}
 
@@ -77,6 +87,11 @@ namespace Correlate
 		/// </remarks>
 		public static T Correlate<T>(this ICorrelationManager correlationManager, Func<T> correlatedFunc, OnException<T> onException)
 		{
+			if (correlationManager is null)
+			{
+				throw new ArgumentNullException(nameof(correlationManager));
+			}
+
 			return correlationManager.Correlate(null, correlatedFunc, onException);
 		}
 
@@ -93,6 +108,11 @@ namespace Correlate
 		/// </remarks>
 		public static T Correlate<T>(this ICorrelationManager correlationManager, string correlationId, Func<T> correlatedFunc)
 		{
+			if (correlationManager is null)
+			{
+				throw new ArgumentNullException(nameof(correlationManager));
+			}
+
 			return correlationManager.Correlate(correlationId, correlatedFunc, null);
 		}
 

--- a/src/Correlate.Core/Extensions/CorrelationManagerExtensions.cs
+++ b/src/Correlate.Core/Extensions/CorrelationManagerExtensions.cs
@@ -30,7 +30,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the action simply executed as it normally would.
 		/// </remarks>
-		public static void Correlate(this ICorrelationManager correlationManager, Action correlatedAction, OnException onException)
+		public static void Correlate(this ICorrelationManager correlationManager, Action correlatedAction, OnException? onException)
 		{
 			if (correlationManager is null)
 			{
@@ -49,7 +49,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the action simply executed as it normally would.
 		/// </remarks>
-		public static void Correlate(this ICorrelationManager correlationManager, string correlationId, Action correlatedAction)
+		public static void Correlate(this ICorrelationManager correlationManager, string? correlationId, Action correlatedAction)
 		{
 			if (correlationManager is null)
 			{
@@ -85,7 +85,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the action simply executed as it normally would.
 		/// </remarks>
-		public static T Correlate<T>(this ICorrelationManager correlationManager, Func<T> correlatedFunc, OnException<T> onException)
+		public static T Correlate<T>(this ICorrelationManager correlationManager, Func<T> correlatedFunc, OnException<T>? onException)
 		{
 			if (correlationManager is null)
 			{
@@ -106,7 +106,7 @@ namespace Correlate
 		/// <remarks>
 		/// When logging and tracing are both disabled, no correlation context is created and the action simply executed as it normally would.
 		/// </remarks>
-		public static T Correlate<T>(this ICorrelationManager correlationManager, string correlationId, Func<T> correlatedFunc)
+		public static T Correlate<T>(this ICorrelationManager correlationManager, string? correlationId, Func<T> correlatedFunc)
 		{
 			if (correlationManager is null)
 			{

--- a/src/Correlate.Core/Extensions/CorrelationManagerExtensions.cs
+++ b/src/Correlate.Core/Extensions/CorrelationManagerExtensions.cs
@@ -18,7 +18,7 @@ namespace Correlate
 		/// </remarks>
 		public static void Correlate(this ICorrelationManager correlationManager, Action correlatedAction)
 		{
-			correlationManager.Correlate(correlatedAction, null);
+			correlationManager.Correlate(null, correlatedAction);
 		}
 
 		/// <summary>
@@ -71,7 +71,7 @@ namespace Correlate
 		/// </remarks>
 		public static T Correlate<T>(this ICorrelationManager correlationManager, Func<T> correlatedFunc)
 		{
-			return correlationManager.Correlate(correlatedFunc, null);
+			return correlationManager.Correlate(null, correlatedFunc);
 		}
 
 		/// <summary>

--- a/src/Correlate.Core/GuidCorrelationIdFactory.cs
+++ b/src/Correlate.Core/GuidCorrelationIdFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Correlate
 {
@@ -12,13 +13,17 @@ namespace Correlate
 		/// </summary>
 		// ReSharper disable once EmptyConstructor
 		public GuidCorrelationIdFactory()
-		{			
+		{
 		}
 
 		/// <inheritdoc />
 		public string Create()
 		{
+#if NETSTANDARD1_3
 			return Guid.NewGuid().ToString("D");
+#else
+			return Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture);
+#endif
 		}
 	}
 }

--- a/src/Correlate.Core/Http/CorrelatingHttpMessageHandler.cs
+++ b/src/Correlate.Core/Http/CorrelatingHttpMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
@@ -41,6 +42,11 @@ namespace Correlate.Http
 		/// <inheritdoc />
 		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 		{
+			if (request is null)
+			{
+				throw new ArgumentNullException(nameof(request));
+			}
+
 			string correlationId = _correlationContextAccessor?.CorrelationContext?.CorrelationId;
 			if (correlationId != null)
 			{

--- a/src/Correlate.Core/Http/CorrelatingHttpMessageHandler.cs
+++ b/src/Correlate.Core/Http/CorrelatingHttpMessageHandler.cs
@@ -47,13 +47,10 @@ namespace Correlate.Http
 				throw new ArgumentNullException(nameof(request));
 			}
 
-			string correlationId = _correlationContextAccessor?.CorrelationContext?.CorrelationId;
-			if (correlationId != null)
+			string? correlationId = _correlationContextAccessor?.CorrelationContext?.CorrelationId;
+			if (correlationId != null && !request.Headers.Contains(_options.RequestHeader))
 			{
-				if (!request.Headers.Contains(_options.RequestHeader))
-				{
-					request.Headers.TryAddWithoutValidation(_options.RequestHeader, correlationId);
-				}
+				request.Headers.TryAddWithoutValidation(_options.RequestHeader, correlationId);
 			}
 
 			return base.SendAsync(request, cancellationToken);

--- a/src/Correlate.Core/Http/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Correlate.Core/Http/Extensions/HeaderDictionaryExtensions.cs
@@ -7,7 +7,7 @@ namespace Correlate.Http.Extensions
 {
 	internal static class HeaderDictionaryExtensions
 	{
-		internal static KeyValuePair<string, string> GetCorrelationIdHeader(this IDictionary<string, StringValues> httpHeaders, ICollection<string> acceptedHeaders)
+		internal static KeyValuePair<string, string?> GetCorrelationIdHeader(this IDictionary<string, StringValues> httpHeaders, ICollection<string> acceptedHeaders)
 		{
 			if (acceptedHeaders == null)
 			{
@@ -16,11 +16,11 @@ namespace Correlate.Http.Extensions
 
 			if (!acceptedHeaders.Any())
 			{
-				return new KeyValuePair<string, string>(CorrelationHttpHeaders.CorrelationId, null);
+				return new KeyValuePair<string, string?>(CorrelationHttpHeaders.CorrelationId, null);
 			}
 
-			string correlationId = null;
-			string headerName = null;
+			string? correlationId = null;
+			string? headerName = null;
 
 			foreach (string requestHeaderName in acceptedHeaders)
 			{
@@ -35,7 +35,7 @@ namespace Correlate.Http.Extensions
 				}
 			}
 
-			return new KeyValuePair<string, string>(
+			return new KeyValuePair<string, string?>(
 				headerName ?? acceptedHeaders.First(),
 				correlationId
 			);

--- a/src/Correlate.Core/RootActivity.cs
+++ b/src/Correlate.Core/RootActivity.cs
@@ -9,13 +9,13 @@ namespace Correlate
 	{
 		private readonly ICorrelationContextFactory _correlationContextFactory;
 		private readonly ILogger _logger;
-		private readonly DiagnosticListener _diagnosticListener;
-		private IDisposable _logScope;
+		private readonly DiagnosticListener? _diagnosticListener;
+		private IDisposable? _logScope;
 
 		public RootActivity(
 			ICorrelationContextFactory correlationContextFactory,
 			ILogger logger,
-			DiagnosticListener diagnosticListener)
+			DiagnosticListener? diagnosticListener)
 		{
 			_correlationContextFactory = correlationContextFactory ?? throw new ArgumentNullException(nameof(correlationContextFactory));
 			_logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
+++ b/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3;net46</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
@@ -10,6 +10,10 @@
     <PackageProjectUrl>https://github.com/skwasjer/Correlate</PackageProjectUrl>
     <PackageTags>correlationid, correlation, correlate, causation, aspnet, middleware, httpclient, httpclientfactory</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.1" />
+  </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />

--- a/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
+++ b/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3;net46</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Correlate.DependencyInjection/IHttpClientBuilderExtensions.cs
+++ b/src/Correlate.DependencyInjection/IHttpClientBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Correlate.DependencyInjection
 		/// <returns>The <see cref="IHttpClientBuilder"/> so that additional calls can be chained.</returns>
 		public static IHttpClientBuilder CorrelateRequests(this IHttpClientBuilder builder, string requestHeader = CorrelationHttpHeaders.CorrelationId)
 		{
-			return CorrelateRequests(builder, options => options.RequestHeader = requestHeader);
+			return builder.CorrelateRequests(options => options.RequestHeader = requestHeader);
 		}
 
 		/// <summary>
@@ -34,7 +34,7 @@ namespace Correlate.DependencyInjection
 		/// <returns>The <see cref="IHttpClientBuilder"/> so that additional calls can be chained.</returns>
 		public static IHttpClientBuilder CorrelateRequests(this IHttpClientBuilder builder, IConfiguration configuration)
 		{
-			return CorrelateRequests(builder, configuration.Bind);
+			return builder.CorrelateRequests(configuration.Bind);
 		}
 
 		/// <summary>

--- a/src/Correlate.DependencyInjection/IHttpClientBuilderExtensions.cs
+++ b/src/Correlate.DependencyInjection/IHttpClientBuilderExtensions.cs
@@ -45,6 +45,11 @@ namespace Correlate.DependencyInjection
 		/// <returns>The <see cref="IHttpClientBuilder"/> so that additional calls can be chained.</returns>
 		public static IHttpClientBuilder CorrelateRequests(this IHttpClientBuilder builder, Action<CorrelateClientOptions> configureOptions)
 		{
+			if (builder is null)
+			{
+				throw new ArgumentNullException(nameof(builder));
+			}
+
 			builder.Services.AddCorrelate();
 
 			builder.Services.TryAddTransient<CorrelatingHttpMessageHandler>();

--- a/src/Correlate.DependencyInjection/IHttpClientBuilderExtensions.cs
+++ b/src/Correlate.DependencyInjection/IHttpClientBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
 using System;
 using System.Net.Http;
 using Correlate.Http;

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/Fixtures/Startup.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/Fixtures/Startup.cs
@@ -1,14 +1,18 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Correlate.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using MockHttp;
+using Serilog.Sinks.TestCorrelator;
 
 namespace Correlate.AspNetCore.Fixtures
 {
 	public class Startup
 	{
+		public static ITestCorrelatorContext LastRequestContext { get; private set; }
+
 		public void ConfigureServices(IServiceCollection services)
 		{
 			services.AddCorrelate();
@@ -18,16 +22,49 @@ namespace Correlate.AspNetCore.Fixtures
 				.ConfigurePrimaryHttpMessageHandler(s => s.GetRequiredService<MockHttpHandler>())
 				.CorrelateRequests();
 
+#if NETCOREAPP3_1
+			services
+				.AddControllers()
+				.AddControllersAsServices();
+#else
 			services
 				.AddMvcCore()
 				.AddControllersAsServices()
-				.SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+				.SetCompatibilityVersion(Microsoft.AspNetCore.Mvc.CompatibilityVersion.Version_2_2);
+#endif
 		}
 
 		public void Configure(IApplicationBuilder app)
 		{
+			// Create context to track log events.
+			app.UseMiddleware<TestContextMiddleware>();
+
 			app.UseCorrelate();
+
+#if NETCOREAPP3_1
+			app.UseRouting();
+			app.UseEndpoints(builder => builder.MapControllers());
+#else
 			app.UseMvc();
+#endif
+		}
+
+		private class TestContextMiddleware
+		{
+			private readonly RequestDelegate _next;
+
+			public TestContextMiddleware(RequestDelegate next)
+			{
+				_next = next ?? throw new ArgumentNullException(nameof(next));
+			}
+
+			public async Task Invoke(HttpContext httpContext)
+			{
+				using (LastRequestContext = TestCorrelator.CreateContext())
+				{
+					await _next.Invoke(httpContext);
+				}
+			}
 		}
 	}
 }

--- a/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
+++ b/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 

--- a/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
+++ b/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Condition="$(TargetFramework.StartsWith('netcoreapp2'))" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" Condition="$(TargetFramework.StartsWith('netcoreapp2'))" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
+++ b/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.2;netcoreapp2.1;netcoreapp1.1;net46</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>Correlate</RootNamespace>

--- a/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
+++ b/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.2;netcoreapp2.1;netcoreapp1.1;net46</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 

--- a/test/Correlate.Core.Tests/CorrelationManagerTests.cs
+++ b/test/Correlate.Core.Tests/CorrelationManagerTests.cs
@@ -109,22 +109,6 @@ namespace Correlate
 			}
 
 			[Fact]
-			public void When_not_providing_task_when_starting_correlation_should_throw()
-			{
-				Func<Task> correlatedTask = null;
-
-				// Act
-				// ReSharper disable once ExpressionIsAlwaysNull
-				Func<Task> act = () => _sut.CorrelateAsync(null, correlatedTask, null);
-
-				// Assert
-				act.Should()
-					.Throw<ArgumentNullException>()
-					.Which.ParamName.Should()
-					.Be(nameof(correlatedTask));
-			}
-
-			[Fact]
 			public void When_provided_task_throws_should_not_wrap_exception()
 			{
 				var exception = new Exception();
@@ -415,22 +399,6 @@ namespace Correlate
 					});
 
 				_correlationIdFactoryMock.Verify(m => m.Create(), Times.Never);
-			}
-
-			[Fact]
-			public void When_not_providing_action_when_starting_correlation_should_throw()
-			{
-				Action correlatedAction = null;
-
-				// Act
-				// ReSharper disable once ExpressionIsAlwaysNull
-				Action act = () => _sut.Correlate(null, correlatedAction, null);
-
-				// Assert
-				act.Should()
-					.Throw<ArgumentNullException>()
-					.Which.ParamName.Should()
-					.Be(nameof(correlatedAction));
 			}
 
 			[Fact]

--- a/test/Correlate.Core.Tests/CorrelationManagerTests.cs
+++ b/test/Correlate.Core.Tests/CorrelationManagerTests.cs
@@ -351,6 +351,32 @@ namespace Correlate
 						.And.ContainSingle(ev => ev.MessageTemplate.Text == "Message with correlation id." && ev.Properties.ContainsKey("CorrelationId"));
 				}
 			}
+
+			[Fact]
+			public void Given_provided_task_throws_but_exception_delegate_is_null_it_should_just_rethrow()
+			{
+				var exception = new Exception();
+				Task ThrowingTask() => throw exception;
+
+				// Act
+				Func<Task> act = () => _sut.CorrelateAsync(null, ThrowingTask, null);
+
+				// Assert
+				act.Should().Throw<Exception>().Which.Should().Be(exception);
+			}
+
+			[Fact]
+			public void Given_provided_task_with_returnValue_throws_but_exception_delegate_is_null_it_should_just_rethrow()
+			{
+				var exception = new Exception();
+				Task<int> ThrowingTask() => throw exception;
+
+				// Act
+				Func<Task<int>> act = () => _sut.CorrelateAsync(null, ThrowingTask, null);
+
+				// Assert
+				act.Should().Throw<Exception>().Which.Should().Be(exception);
+			}
 		}
 
 		public class Sync : CorrelationManagerTests
@@ -456,10 +482,7 @@ namespace Correlate
 			{
 				var exception = new Exception();
 
-				int ThrowingFunc()
-				{
-					throw exception;
-				}
+				int ThrowingFunc() => throw exception;
 
 				const int returnValue = 12345;
 
@@ -603,6 +626,34 @@ namespace Correlate
 						.HaveCount(3)
 						.And.ContainSingle(ev => ev.MessageTemplate.Text == "Message with correlation id." && ev.Properties.ContainsKey("CorrelationId"));
 				}
+			}
+
+			[Fact]
+			public void Given_provided_action_throws_but_exception_delegate_is_null_it_should_just_rethrow()
+			{
+				var exception = new Exception();
+				// ReSharper disable once ConvertToLocalFunction
+				Action throwingAction = () => throw exception;
+
+				// Act
+				Action act = () => _sut.Correlate(null, throwingAction, null);
+
+				// Assert
+				act.Should().Throw<Exception>().Which.Should().Be(exception);
+			}
+
+			[Fact]
+			public void Given_provided_func_throws_but_exception_delegate_is_null_it_should_just_rethrow()
+			{
+				var exception = new Exception();
+				// ReSharper disable once ConvertToLocalFunction
+				Func<int> throwingFunc = () => throw exception;
+
+				// Act
+				Func<int> act = () => _sut.Correlate(null, throwingFunc, null);
+
+				// Assert
+				act.Should().Throw<Exception>().Which.Should().Be(exception);
 			}
 		}
 

--- a/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
+++ b/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.2;netcoreapp2.1;netcoreapp1.1;net46</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>Correlate.DependencyInjection</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
+  </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp2'))">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />

--- a/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
+++ b/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.2;netcoreapp2.1;netcoreapp1.1;net46</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
     <RootNamespace>Correlate.DependencyInjection</RootNamespace>
   </PropertyGroup>
 

--- a/test/Correlate.DependencyInjection.Tests/IHttpClientBuilderExtensionsTests.cs
+++ b/test/Correlate.DependencyInjection.Tests/IHttpClientBuilderExtensionsTests.cs
@@ -113,7 +113,11 @@ namespace Correlate.DependencyInjection
 				yield return new ExpectedRegistration<CorrelatingHttpMessageHandler, CorrelatingHttpMessageHandler>(ServiceLifetime.Transient);
 				// AddHttpMessageHandler with options:
 				yield return new ExpectedRegistration<IConfigureOptions<CorrelateClientOptions>, ConfigureNamedOptions<CorrelateClientOptions>>(ServiceLifetime.Singleton);
+#if NETCOREAPP3_1
+				yield return new ExpectedRegistration<IConfigureOptions<HttpClientFactoryOptions>>(ServiceLifetime.Singleton);
+#else
 				yield return new ExpectedRegistration<IConfigureOptions<HttpClientFactoryOptions>>(ServiceLifetime.Transient);
+#endif
 				yield return new ExpectedRegistration<MyService>(ServiceLifetime.Transient);
 			}
 		}

--- a/test/Correlate.Testing/Correlate.Testing.csproj
+++ b/test/Correlate.Testing/Correlate.Testing.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3;net46</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
+  </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />

--- a/test/Correlate.Testing/Correlate.Testing.csproj
+++ b/test/Correlate.Testing/Correlate.Testing.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3;net46</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/test/Correlate.Testing/FluentAssertions/DelegateAssertions.cs
+++ b/test/Correlate.Testing/FluentAssertions/DelegateAssertions.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Reflection;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Specialized;
+
+namespace Correlate.Testing.FluentAssertions
+{
+	public class DelegateAssertions : DelegateAssertions<Delegate>
+	{
+		public DelegateAssertions(Delegate @delegate, IExtractExceptions extractor) : base(@delegate, extractor)
+		{
+		}
+
+		protected override string Identifier => GetType().Name;
+
+		protected override void InvokeSubject()
+		{
+			Subject.DynamicInvoke();
+		}
+
+		/// <summary>
+		/// Asserts that the current <see cref="T:System.Delegate" /> throws an exception of type <typeparamref name="TException" />.
+		/// </summary>
+		/// <param name="args">The arguments.</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="!:because" />.
+		/// </param>
+		public ExceptionAssertions<TException> Throw<TException>(
+			object[] args,
+			string because = "",
+			params object[] becauseArgs)
+			where TException : Exception
+		{
+			Execute.Assertion
+				.ForCondition((object)Subject != null)
+				.BecauseOf(because, becauseArgs)
+				.FailWith("Expected {context} to throw {0}{reason}, but found <null>.", (object)typeof(TException));
+
+			return Throw<TException>(InvokeSubjectWithInterception(args), because, becauseArgs);
+		}
+
+		/// <summary>
+		/// Asserts that the current <see cref="Delegate" /> does not throw any exception.
+		/// </summary>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="!:because" />.
+		/// </param>
+		public new AndWhichConstraint<DelegateAssertions, object> NotThrow(
+			string because = "",
+			params object[] becauseArgs)
+		{
+			Execute.Assertion
+				.ForCondition(Subject != null)
+				.BecauseOf(because, becauseArgs)
+				.FailWith("Expected {context} not to throw{reason}, but found <null>.");
+			try
+			{
+				// ReSharper disable once PossibleNullReferenceException
+				return new AndWhichConstraint<DelegateAssertions, object>(this, Subject.DynamicInvoke());
+			}
+			catch (TargetInvocationException ex) when (ex.InnerException != null)
+			{
+				NotThrow(ex.InnerException, because, becauseArgs);
+				return new AndWhichConstraint<DelegateAssertions, object>(this, default);
+			}
+			catch (Exception ex)
+			{
+				NotThrow(ex, because, becauseArgs);
+				return new AndWhichConstraint<DelegateAssertions, object>(this, default);
+			}
+		}
+
+		/// <summary>
+		/// Asserts that the current <see cref="Delegate" /> does not throw any exception.
+		/// </summary>
+		/// <param name="args">The arguments.</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="!:because" />.
+		/// </param>
+		public AndWhichConstraint<DelegateAssertions, object> NotThrow(
+			object[] args,
+			string because = "",
+			params object[] becauseArgs)
+		{
+			Execute.Assertion
+				.ForCondition(Subject != null)
+				.BecauseOf(because, becauseArgs)
+				.FailWith("Expected {context} not to throw{reason}, but found <null>.");
+			try
+			{
+				// ReSharper disable once PossibleNullReferenceException
+				return new AndWhichConstraint<DelegateAssertions, object>(this, Subject.DynamicInvoke(args));
+			}
+			catch (TargetInvocationException ex) when (ex.InnerException != null)
+			{
+				NotThrow(ex.InnerException, because, becauseArgs);
+				return new AndWhichConstraint<DelegateAssertions, object>(this, default);
+			}
+			catch (Exception ex)
+			{
+				NotThrow(ex, because, becauseArgs);
+				return new AndWhichConstraint<DelegateAssertions, object>(this, default);
+			}
+		}
+
+		private Exception InvokeSubjectWithInterception(object[] args)
+		{
+			Exception exception = null;
+			try
+			{
+				Subject.DynamicInvoke(args);
+			}
+			catch (TargetInvocationException ex) when (ex.InnerException != null)
+			{
+				exception = ex.InnerException;
+			}
+			catch (Exception ex)
+			{
+				exception = ex;
+			}
+			return exception;
+		}
+	}
+}

--- a/test/Correlate.Testing/FluentAssertions/DelegateExtensions.cs
+++ b/test/Correlate.Testing/FluentAssertions/DelegateExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using FluentAssertions;
+
+namespace Correlate.Testing.FluentAssertions
+{
+	public static class DelegateExtensions
+	{
+		public static DelegateAssertions Should(this Delegate instance)
+		{
+			return new DelegateAssertions(instance, new AggregateExceptionExtractor());
+		}
+	}
+}

--- a/test/Correlate.Testing/NullLogger.cs
+++ b/test/Correlate.Testing/NullLogger.cs
@@ -3,7 +3,7 @@
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging.Abstractions
 {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1
 	/// <summary>
 	/// Polyfill for frameworks older than NET Core 2.
 	/// </summary>

--- a/test/Correlate.Testing/TestCases/DelegateTestCase.cs
+++ b/test/Correlate.Testing/TestCases/DelegateTestCase.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Correlate.Testing.TestCases
+{
+	public class DelegateTestCase : List<object>
+	{
+		public string Name { get; }
+		public Delegate Delegate { get; }
+
+		private DelegateTestCase(Delegate @delegate)
+		{
+			Name = @delegate.GetMethodInfo().Name;
+			Delegate = @delegate;
+			Add(Name);
+			Add(@delegate);
+		}
+
+		public IEnumerable<object[]> GetNullArgumentTestCases(bool withoutName = false)
+		{
+			const int paramOffset = 2;
+			MethodInfo methodInfo = Delegate.GetMethodInfo();
+			ParameterInfo[] parameters = methodInfo.GetParameters();
+			for (int i = paramOffset; i < Count; i++)
+			{
+				ParameterInfo parameter = parameters[i - paramOffset];
+
+				// Ignore value types.
+				if (parameter.ParameterType.GetTypeInfo().IsValueType)
+				{
+					continue;
+				}
+
+				if (this[i] is null)
+				{
+					// If value is null, then null is allowed and we ignore case.
+					continue;
+				}
+
+				// Set value for current case to null.
+				var testCase = new List<object>(this)
+				{
+					[i] = null!
+				};
+
+				// Insert current parameter name.
+				testCase.Insert(paramOffset, parameter.Name!);
+
+				yield return testCase.Skip(withoutName ? 1 : 0).ToArray();
+			}
+		}
+
+		public object[] WithoutName()
+		{
+			return this.Skip(1).ToArray();
+		}
+
+		public static DelegateTestCase Create<TOut>(Func<TOut> @delegate)
+		{
+			return new DelegateTestCase(@delegate);
+		}
+
+		public static DelegateTestCase Create<T1, TOut>(Func<T1, TOut> @delegate, T1 arg1)
+		{
+			return new DelegateTestCase(@delegate)
+			{
+				arg1!,
+			};
+		}
+
+		public static DelegateTestCase Create<T1, T2, TOut>(Func<T1, T2, TOut> @delegate, T1 arg1, T2 arg2)
+		{
+			return new DelegateTestCase(@delegate)
+			{
+				arg1!, arg2!
+			};
+		}
+
+		public static DelegateTestCase Create<T1, T2>(Action<T1, T2> @delegate, T1 arg1, T2 arg2)
+		{
+			return new DelegateTestCase(@delegate)
+			{
+				arg1!, arg2!
+			};
+		}
+
+		public static DelegateTestCase Create<T1, T2, T3, TOut>(Func<T1, T2, T3, TOut> @delegate, T1 arg1, T2 arg2, T3 arg3)
+		{
+			return new DelegateTestCase(@delegate)
+			{
+				arg1!, arg2!, arg3!
+			};
+		}
+
+		public static DelegateTestCase Create<T1, T2, T3>(Action<T1, T2, T3> @delegate, T1 arg1, T2 arg2, T3 arg3)
+		{
+			return new DelegateTestCase(@delegate)
+			{
+				arg1!, arg2!, arg3!
+			};
+		}
+
+		public static DelegateTestCase Create<T1, T2, T3, T4, TOut>(Func<T1, T2, T3, T4, TOut> @delegate, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+		{
+			return new DelegateTestCase(@delegate)
+			{
+				arg1!, arg2!, arg3!, arg4!
+			};
+		}
+
+		public static DelegateTestCase Create<T1, T2, T3, T4, T5, TOut>(Func<T1, T2, T3, T4, T5, TOut> @delegate, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+		{
+			return new DelegateTestCase(@delegate)
+			{
+				arg1!, arg2!, arg3!, arg4!, arg5!
+			};
+		}
+	}
+}

--- a/test/Correlate.Testing/TestCases/NullArgumentCheckFixture.cs
+++ b/test/Correlate.Testing/TestCases/NullArgumentCheckFixture.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Correlate.Testing.FluentAssertions;
+using FluentAssertions;
+
+namespace Correlate.Testing.TestCases
+{
+	public static class NullArgumentTest
+	{
+		public static void Execute(params object[] testArgs)
+		{
+			if (testArgs is null)
+			{
+				throw new ArgumentNullException(nameof(testArgs));
+			}
+
+			string testCase = (string)testArgs[0];
+			var func = (Delegate)testArgs[1];
+			string expectedParamName = (string)testArgs[2];
+			ParameterInfo param = func.GetMethodInfo().GetParameters().Single(p => p.Name == expectedParamName);
+			object[] args = testArgs.Skip(3).ToArray();
+			if (args.Length == 0)
+			{
+				// args can be empty for single param, so in that case provide array with 1 item.
+				args = new object[1];
+			}
+
+			ArgumentException ex = param.ParameterType == typeof(string)
+				? func.Should().Throw<ArgumentException>(args).Which
+				: func.Should().Throw<ArgumentNullException>(args).Which;
+			string paramName = ex.ParamName;
+			paramName.Should().Be(expectedParamName, "no null was provided for {1}", expectedParamName, testCase);
+		}
+	}
+}

--- a/test/Correlate.Testing/TestCases/NullArgumentTestCases.cs
+++ b/test/Correlate.Testing/TestCases/NullArgumentTestCases.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Correlate.Testing.TestCases
+{
+	public class NullArgumentTestCases : List<DelegateTestCase>
+	{
+		public IEnumerable<object[]> Flatten()
+			=> this
+				.SelectMany(tc => tc.GetNullArgumentTestCases())
+				.ToList();
+	}
+}

--- a/test/Correlate.Testing/TestLogger.cs
+++ b/test/Correlate.Testing/TestLogger.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Correlate.Testing
 {
@@ -45,7 +45,7 @@ namespace Correlate.Testing
 
 		public IDisposable BeginScope<TState>(TState state)
 		{
-			return _innerLogger?.BeginScope(state) ?? NullScope.Instance;
+			return _innerLogger?.BeginScope(state) ?? NullLogger.Instance.BeginScope(state);
 		}
 	}
 }

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- .NET Standard 2.1 support (for .NET Core 3.x, with newer Microsoft.* dependencies)
- Update API contracts with non-nullable ref types
- Fix several potential NRE's