### PR TITLE
chore(deps): remove System.Diagnostics.DiagnosticSource from .NET6/7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,11 +14,6 @@
     <PackageVersion_Microsoft_Extensions>7.0.0</PackageVersion_Microsoft_Extensions>
     <PackageVersion_Microsoft_Extensions Condition="'$(TargetFramework)'=='net6.0'">6.0.0</PackageVersion_Microsoft_Extensions>
     <PackageVersion_Microsoft_Extensions Condition="'$(TargetFramework)'!='net6.0' And '$(TargetFramework)'!='net7.0'">3.1.26</PackageVersion_Microsoft_Extensions>
-
-    <!-- System.Diagnostics.DiagnosticSource -->
-    <PackageVersion_DiagnosticSource>7.0.0</PackageVersion_DiagnosticSource>
-    <PackageVersion_DiagnosticSource Condition="'$(TargetFramework)'=='net6.0'">6.0.0</PackageVersion_DiagnosticSource>
-    <PackageVersion_DiagnosticSource Condition="'$(TargetFramework)'!='net6.0' And '$(TargetFramework)'!='net7.0'">4.7.0</PackageVersion_DiagnosticSource>
   </PropertyGroup>
 
 </Project>

--- a/src/Correlate.Core/Correlate.Core.csproj
+++ b/src/Correlate.Core/Correlate.Core.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(PackageVersion_Microsoft_Extensions)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(PackageVersion_Microsoft_Extensions)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(PackageVersion_DiagnosticSource)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" Condition="$(TargetFramework)=='netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`System.Diagnostics.DiagnosticSource` is already transitively available in .NET6/7.