### PR TITLE
feat!: move CorrelateOptions to parent namespace

### DIFF
--- a/src/Correlate.AspNetCore/AspNetCore/CorrelateFeature.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/CorrelateFeature.cs
@@ -1,5 +1,4 @@
-﻿using Correlate.AspNetCore.Middleware;
-using Correlate.Http.Extensions;
+﻿using Correlate.Http.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/Correlate.AspNetCore/AspNetCore/CorrelateOptions.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/CorrelateOptions.cs
@@ -1,6 +1,6 @@
 ﻿using Correlate.Http;
 
-namespace Correlate.AspNetCore.Middleware;
+namespace Correlate.AspNetCore;
 
 /// <summary>
 /// Options for handling correlation id on incoming requests.

--- a/src/Correlate.AspNetCore/AspNetCore/CorrelateOptions.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/CorrelateOptions.cs
@@ -5,21 +5,30 @@ namespace Correlate.AspNetCore;
 /// <summary>
 /// Options for handling correlation id on incoming requests.
 /// </summary>
-public class CorrelateOptions
+public sealed class CorrelateOptions
 {
+    private static readonly string[] DefaultRequestHeaders = { CorrelationHttpHeaders.CorrelationId };
+
+    private string[]? _requestHeaders;
+
     /// <summary>
-    /// Gets or sets the request headers to retrieve the correlation id from.
+    /// Gets or sets the request headers to retrieve the correlation id from. Defaults to <c>X-Correlation-ID</c>.
     /// </summary>
     /// <remarks>
-    /// The first matching header will be used.
+    /// The first matching request header will be used.
     /// </remarks>
-    public string[] RequestHeaders { get; set; } = { CorrelationHttpHeaders.CorrelationId };
+    public string[] RequestHeaders
+    {
+        get => _requestHeaders ?? DefaultRequestHeaders;
+        set => _requestHeaders = value;
+    }
 
     /// <summary>
     /// Gets or sets whether to include the correlation id in the response.
+    /// <para>If the correlation id was received in the request, it will use the exact same header name in the response. If the request did not have a correlation id header (matching one in <see cref="RequestHeaders" />), the default response header will be <c>X-Correlation-ID</c>.</para>
     /// </summary>
     /// <remarks>
-    /// A common use case is to disable tracing info in edge services, so that such details are not exposed to the outside world.
+    /// You may want to consider disabling this in edge services, so that tracing details are not exposed to the outside world.
     /// </remarks>
     public bool IncludeInResponse { get; set; } = true;
 }

--- a/src/Correlate.AspNetCore/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Correlate.AspNetCore/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Correlate.AspNetCore.Middleware;
+﻿using Correlate.AspNetCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Correlate.DependencyInjection;

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/AppBuilderExtensionsTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/AppBuilderExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using Correlate.AspNetCore.Middleware;
-using Correlate.DependencyInjection;
+﻿using Correlate.DependencyInjection;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Options;

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/CorrelateFeatureTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/CorrelateFeatureTests.cs
@@ -1,5 +1,4 @@
-﻿using Correlate.AspNetCore.Middleware;
-using Correlate.Http;
+﻿using Correlate.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/IntegrationTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/IntegrationTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using Correlate.AspNetCore.Fixtures;
-using Correlate.AspNetCore.Middleware;
 using Correlate.Http;
 using Correlate.Testing.FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;


### PR DESCRIPTION
Originally, `CorrelateOptions` resided in the `Correlate.AspNetCore.Middleware` namespace, but the middleware implementation was removed in #47. As such it makes more sense to remove the namespace as well by moving the options class a level up.

Further did some minor improvements:
- sealed the type
- made sure the `RequestHeaders` property is never null as this could lead to NRE's
- improved the XML docs

> Because the type is moved, this is a contract breaking API change