### PR TITLE
perf: add benchmark to validate and guard for regression

### DIFF
--- a/Correlate.sln
+++ b/Correlate.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Correlate.DependencyInjecti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Correlate.Testing", "test\Correlate.Testing\Correlate.Testing.csproj", "{27F547F7-01DE-4B18-9035-0223A80970E4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Correlate.Benchmarks", "test\Correlate.Benchmarks\Correlate.Benchmarks.csproj", "{3CDE7B0E-5527-4106-A208-1FA6BC06F2B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +80,10 @@ Global
 		{27F547F7-01DE-4B18-9035-0223A80970E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27F547F7-01DE-4B18-9035-0223A80970E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27F547F7-01DE-4B18-9035-0223A80970E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CDE7B0E-5527-4106-A208-1FA6BC06F2B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CDE7B0E-5527-4106-A208-1FA6BC06F2B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CDE7B0E-5527-4106-A208-1FA6BC06F2B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CDE7B0E-5527-4106-A208-1FA6BC06F2B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -91,6 +97,7 @@ Global
 		{588D9B34-82DA-46A3-BA75-F311382DAB45} = {45C7B4DF-E612-4301-B2D3-164650B05FC6}
 		{6506DA5B-F341-4B6A-92A9-A2583A43C625} = {45C7B4DF-E612-4301-B2D3-164650B05FC6}
 		{27F547F7-01DE-4B18-9035-0223A80970E4} = {45C7B4DF-E612-4301-B2D3-164650B05FC6}
+		{3CDE7B0E-5527-4106-A208-1FA6BC06F2B9} = {45C7B4DF-E612-4301-B2D3-164650B05FC6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BE2CCEF9-2685-4DF3-B085-B6FB083E8E56}

--- a/test/Correlate.Benchmarks/.gitignore
+++ b/test/Correlate.Benchmarks/.gitignore
@@ -1,0 +1,1 @@
+/BenchmarkDotNet.Artifacts

--- a/test/Correlate.Benchmarks/AspNetCoreBenchmark.cs
+++ b/test/Correlate.Benchmarks/AspNetCoreBenchmark.cs
@@ -1,0 +1,67 @@
+﻿using BenchmarkDotNet.Attributes;
+using Correlate.AspNetCore;
+using Correlate.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Correlate.Benchmarks;
+
+#if RELEASE
+[MemoryDiagnoser]
+[BenchmarkDotNet.Diagnostics.Windows.Configs.InliningDiagnoser(false, new[] { "Correlate.AspNetCore" })]
+#endif
+[StopOnFirstError]
+[MarkdownExporter]
+public class AspNetCoreBenchmark
+{
+    private WebApplication? _app;
+    private HttpClient? _httpClient;
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        const string hostUrl = "http://localhost:5000";
+        _httpClient = new HttpClient { BaseAddress = new Uri(hostUrl) };
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls(hostUrl);
+        builder.Services.AddCorrelate();
+
+        _app = builder.Build();
+        _app.UseCorrelate();
+        _app.MapGet("/hello",
+            (ICorrelationContextAccessor ctx) =>
+            {
+                if (ctx.CorrelationContext?.CorrelationId is not null)
+                {
+                    return;
+                }
+
+                throw new InvalidOperationException("No correlation ID.");
+            });
+
+        await _app.StartAsync();
+    }
+
+    [GlobalCleanup]
+    public async Task GlobalCleanup()
+    {
+        _httpClient?.Dispose();
+        if (_app is null)
+        {
+            return;
+        }
+
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+
+    [Benchmark]
+    public async Task ApiCall()
+    {
+        using HttpResponseMessage response = await _httpClient!.GetAsync("hello");
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/test/Correlate.Benchmarks/Correlate.Benchmarks.csproj
+++ b/test/Correlate.Benchmarks/Correlate.Benchmarks.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>false</IsTestProject>
+    <Baseline>true</Baseline>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Correlate.AspNetCore\Correlate.AspNetCore.csproj" Condition="'$(Baseline)'=='true'" />
+    <ProjectReference Include="..\..\src\Correlate.DependencyInjection\Correlate.DependencyInjection.csproj" Condition="'$(Baseline)'=='true'" />
+  </ItemGroup>
+
+</Project>

--- a/test/Correlate.Benchmarks/Program.cs
+++ b/test/Correlate.Benchmarks/Program.cs
@@ -1,0 +1,39 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.CsProj;
+using Correlate.Benchmarks;
+
+IToolchain[] toolchains = { CsProjCoreToolchain.NetCoreApp70, CsProjCoreToolchain.NetCoreApp60 };
+
+IConfig cfg = DefaultConfig.Instance
+    .ForAllToolchains(toolchains, Job.Default.WithId("Current"), toolchain => toolchain.Equals(CsProjCoreToolchain.NetCoreApp70))
+    .ForAllToolchains(toolchains,
+        Job.Default
+            .WithId("4.0.0")
+            .WithToolchain(CsProjCoreToolchain.NetCoreApp70)
+            .WithNuGet("Correlate.AspNetCore", "4.0.0")
+            .WithNuGet("Correlate.DependencyInjection", "4.0.0")
+            .WithArguments(new[] { new MsBuildArgument("/p:Baseline=false") })
+    );
+
+#if RELEASE
+BenchmarkRunner.Run<AspNetCoreBenchmark>(cfg);
+#else
+BenchmarkRunner.Run<AspNetCoreBenchmark>(new DebugInProcessConfig());
+#endif
+
+internal static class ConfigExtensions
+{
+    public static IConfig ForAllToolchains(this IConfig config, IEnumerable<IToolchain> toolchains, Job job, Func<IToolchain, bool>? isBaseline = null)
+    {
+        foreach (IToolchain toolchain in toolchains)
+        {
+            Job j = job.WithToolchain(toolchain);
+            config = config.AddJob(isBaseline?.Invoke(toolchain) ?? false ? j.AsBaseline() : j);
+        }
+
+        return config;
+    }
+}

--- a/test/Correlate.Benchmarks/README.md
+++ b/test/Correlate.Benchmarks/README.md
@@ -1,0 +1,25 @@
+# Benchmark results
+
+```
+BenchmarkDotNet v0.13.7, Windows 10 (10.0.19045.3324/22H2/2022Update)
+Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK 7.0.400
+  [Host]  : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
+  4.0.0   : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
+  Current : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
+```
+
+|  Method |     Job |         Arguments |                                                NuGetReferences | Toolchain |     Mean |   Error |  StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
+|-------- |-------- |------------------ |--------------------------------------------------------------- |---------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| ApiCall |   4.0.0 | /p:Baseline=false | Correlate.AspNetCore 4.0.0,Correlate.DependencyInjection 4.0.0 |  .NET 6.0 | 148.2 us | 1.95 us | 1.73 us |  1.02 |    0.02 | 0.4883 |   4.33 KB |        1.11 |
+| ApiCall |   4.0.0 | /p:Baseline=false | Correlate.AspNetCore 4.0.0,Correlate.DependencyInjection 4.0.0 |  .NET 7.0 | 148.1 us | 0.93 us | 0.87 us |  1.02 |    0.01 | 0.4883 |   4.06 KB |        1.04 |
+| ApiCall | Current |           Default |                                                        Default |  .NET 6.0 | 140.2 us | 1.12 us | 1.05 us |  0.96 |    0.01 | 0.4883 |   4.16 KB |        1.07 |
+| ApiCall | Current |           Default |                                                        Default |  .NET 7.0 | 145.8 us | 1.07 us | 1.00 us |  1.00 |    0.00 | 0.4883 |   3.91 KB |        1.00 |
+
+### CLI
+
+To run the benchmark:
+```
+cd ./test/Correlate.Benchmarks
+dotnet run -c Release -f net7.0 net6.0
+```


### PR DESCRIPTION
To run the benchmark:
```
cd ./test/Correlate.Benchmarks
dotnet run -c Release -f net7.0 net6.0
```