### PR TITLE
feat: add .NET 8 target framework

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,9 +12,10 @@
 
   <PropertyGroup>
     <!-- Microsoft.Extensions.* -->
-    <PackageVersion_Microsoft_Extensions>7.0.0</PackageVersion_Microsoft_Extensions>
+    <PackageVersion_Microsoft_Extensions>8.0.0</PackageVersion_Microsoft_Extensions>
+    <PackageVersion_Microsoft_Extensions Condition="'$(TargetFramework)'=='net7.0'">7.0.0</PackageVersion_Microsoft_Extensions>
     <PackageVersion_Microsoft_Extensions Condition="'$(TargetFramework)'=='net6.0'">6.0.0</PackageVersion_Microsoft_Extensions>
-    <PackageVersion_Microsoft_Extensions Condition="'$(TargetFramework)'!='net6.0' And '$(TargetFramework)'!='net7.0'">3.1.26</PackageVersion_Microsoft_Extensions>
+    <PackageVersion_Microsoft_Extensions Condition="$(TargetFramework.StartsWith('netstandard2')) Or '$(TargetFramework)'=='netcoreapp3.1'">3.1.26</PackageVersion_Microsoft_Extensions>
   </PropertyGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,13 @@ install:
   - gitversion /l console /output buildserver
   - choco install opencover.portable -y
   - choco install codecov -y
+  # Install 8.0 preview
+  - ps: $env:DOTNET_INSTALL_DIR = "C:\Program Files\dotnet"
+  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
+  - ps: Invoke-WebRequest 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1' -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Channel 8.0.1xx -Quality preview -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  - dotnet --list-sdks
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml, codecov.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml, codecov.yml

--- a/src/Correlate.Abstractions/Correlate.Abstractions.csproj
+++ b/src/Correlate.Abstractions/Correlate.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 

--- a/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
+++ b/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 

--- a/src/Correlate.Core/Correlate.Core.csproj
+++ b/src/Correlate.Core/Correlate.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(PackageVersion_Microsoft_Extensions)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(PackageVersion_Microsoft_Extensions)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" Condition="$(TargetFramework)=='netstandard2.0'" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" Condition="'$(TargetFramework)'=='netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
+++ b/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/CorrelateFeatureTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/CorrelateFeatureTests.cs
@@ -194,7 +194,7 @@ public sealed class CorrelateFeatureTests : IDisposable
         _options.RequestHeaders.Should().NotBeNullOrEmpty();
 
         const string existingCorrelationId = "existing-id";
-        _responseFeature.Headers.Add(_options.RequestHeaders[0], existingCorrelationId);
+        _responseFeature.Headers.Append(_options.RequestHeaders[0], existingCorrelationId);
 
         var expectedHeader = new KeyValuePair<string, StringValues>(
             _options.RequestHeaders[0],

--- a/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
+++ b/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" Condition="'$(TargetFramework)'=='net8.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" Condition="'$(TargetFramework)'=='net7.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" Condition="'$(TargetFramework)'=='net6.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.32" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
-    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" Condition="$(TargetFramework)=='net7.0'" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" Condition="$(TargetFramework)!='net7.0'" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" Condition="'$(TargetFramework)'=='net8.0'" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" Condition="'$(TargetFramework)'!='net8.0' And '$(TargetFramework)'!='net7.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Correlate.Benchmarks/Correlate.Benchmarks.csproj
+++ b/test/Correlate.Benchmarks/Correlate.Benchmarks.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>false</IsTestProject>
-    <Baseline>true</Baseline>
+    <CurrentVersion>true</CurrentVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Correlate.AspNetCore\Correlate.AspNetCore.csproj" Condition="'$(Baseline)'=='true'" />
-    <ProjectReference Include="..\..\src\Correlate.DependencyInjection\Correlate.DependencyInjection.csproj" Condition="'$(Baseline)'=='true'" />
+    <ProjectReference Include="..\..\src\Correlate.AspNetCore\Correlate.AspNetCore.csproj" Condition="'$(CurrentVersion)'=='true'" />
+    <ProjectReference Include="..\..\src\Correlate.DependencyInjection\Correlate.DependencyInjection.csproj" Condition="'$(CurrentVersion)'=='true'" />
   </ItemGroup>
 
 </Project>

--- a/test/Correlate.Benchmarks/README.md
+++ b/test/Correlate.Benchmarks/README.md
@@ -1,25 +1,31 @@
 # Benchmark results
 
 ```
-BenchmarkDotNet v0.13.7, Windows 10 (10.0.19045.3324/22H2/2022Update)
+BenchmarkDotNet v0.13.10, Windows 10 (10.0.19045.3693/22H2/2022Update)
 Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
-.NET SDK 7.0.400
-  [Host]  : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
-  4.0.0   : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
-  Current : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host] : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  v4.0.0 : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2
+  v5.1.0 : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2
+  vNext  : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2
 ```
 
-|  Method |     Job |         Arguments |                                                NuGetReferences | Toolchain |     Mean |   Error |  StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
-|-------- |-------- |------------------ |--------------------------------------------------------------- |---------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| ApiCall |   4.0.0 | /p:Baseline=false | Correlate.AspNetCore 4.0.0,Correlate.DependencyInjection 4.0.0 |  .NET 6.0 | 148.2 us | 1.95 us | 1.73 us |  1.02 |    0.02 | 0.4883 |   4.33 KB |        1.11 |
-| ApiCall |   4.0.0 | /p:Baseline=false | Correlate.AspNetCore 4.0.0,Correlate.DependencyInjection 4.0.0 |  .NET 7.0 | 148.1 us | 0.93 us | 0.87 us |  1.02 |    0.01 | 0.4883 |   4.06 KB |        1.04 |
-| ApiCall | Current |           Default |                                                        Default |  .NET 6.0 | 140.2 us | 1.12 us | 1.05 us |  0.96 |    0.01 | 0.4883 |   4.16 KB |        1.07 |
-| ApiCall | Current |           Default |                                                        Default |  .NET 7.0 | 145.8 us | 1.07 us | 1.00 us |  1.00 |    0.00 | 0.4883 |   3.91 KB |        1.00 |
+| Method  | Job    | Runtime  | Arguments               | NuGetReferences                                                | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|-------- |------- |--------- |------------------------ |--------------------------------------------------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| ApiCall | v4.0.0 | .NET 6.0 | /p:CurrentVersion=false | Correlate.AspNetCore 4.0.0,Correlate.DependencyInjection 4.0.0 | 169.6 us | 1.53 us | 1.36 us |  1.04 |    0.01 | 0.4883 |   4.33 KB |        1.15 |
+| ApiCall | v4.0.0 | .NET 7.0 | /p:CurrentVersion=false | Correlate.AspNetCore 4.0.0,Correlate.DependencyInjection 4.0.0 | 174.8 us | 1.96 us | 1.64 us |  1.07 |    0.01 | 0.4883 |   4.06 KB |        1.08 |
+| ApiCall | v4.0.0 | .NET 8.0 | /p:CurrentVersion=false | Correlate.AspNetCore 4.0.0,Correlate.DependencyInjection 4.0.0 | 165.5 us | 2.35 us | 2.20 us |  1.02 |    0.02 | 0.4883 |   3.87 KB |        1.03 |
+| ApiCall | v5.1.0 | .NET 6.0 | /p:CurrentVersion=false | Correlate.AspNetCore 5.1.0,Correlate.DependencyInjection 5.1.0 | 168.7 us | 2.30 us | 2.15 us |  1.03 |    0.01 | 0.4883 |   4.17 KB |        1.11 |
+| ApiCall | v5.1.0 | .NET 7.0 | /p:CurrentVersion=false | Correlate.AspNetCore 5.1.0,Correlate.DependencyInjection 5.1.0 | 169.9 us | 0.78 us | 0.65 us |  1.04 |    0.01 | 0.4883 |   3.91 KB |        1.04 |
+| ApiCall | v5.1.0 | .NET 8.0 | /p:CurrentVersion=false | Correlate.AspNetCore 5.1.0,Correlate.DependencyInjection 5.1.0 | 162.6 us | 2.31 us | 2.05 us |  0.99 |    0.01 | 0.4883 |   3.75 KB |        1.00 |
+| ApiCall | vNext  | .NET 6.0 | Default                 | Default                                                        | 166.2 us | 1.70 us | 1.50 us |  1.02 |    0.02 | 0.4883 |   4.17 KB |        1.11 |
+| ApiCall | vNext  | .NET 7.0 | Default                 | Default                                                        | 170.6 us | 1.15 us | 1.02 us |  1.05 |    0.01 | 0.4883 |   3.91 KB |        1.04 |
+| ApiCall | vNext  | .NET 8.0 | Default                 | Default                                                        | 163.2 us | 1.60 us | 1.34 us |  1.00 |    0.00 | 0.4883 |   3.75 KB |        1.00 |
 
 ### CLI
 
 To run the benchmark:
 ```
 cd ./test/Correlate.Benchmarks
-dotnet run -c Release -f net7.0 net6.0
+dotnet run -c Release -f net8.0 --runtimes net80 net70 net60
 ```

--- a/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
+++ b/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>

--- a/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
+++ b/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Correlate.DependencyInjection</RootNamespace>
   </PropertyGroup>

--- a/test/Correlate.Testing/Correlate.Testing.csproj
+++ b/test/Correlate.Testing/Correlate.Testing.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
@@ -12,8 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" Condition="$(TargetFramework)=='net7.0'" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" Condition="$(TargetFramework)!='net7.0'" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)'=='net8.0'" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" Condition="'$(TargetFramework)'!='net8.0' And '$(TargetFramework)'!='net7.0'" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="skwas.MockHttp" Version="4.1.1" />
   </ItemGroup>


### PR DESCRIPTION
Tested for performance/regressions.

> AppVeyor build will fail because it does not have .NET 8