### PR TITLE
ci: macos-latest has updated to ARM-based MacOS 14 which causes pipeline fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,9 +100,9 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-latest
-        - windows-latest
-        - macos-latest
+          - ubuntu-latest
+          - windows-latest
+          - macos-13
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Downgrade MacOS runner to v13

https://github.com/actions/runner-images/issues/9741