### PR TITLE
chore: move versions/conditions to PropertyGroup. 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,9 +19,18 @@
   <PropertyGroup>
     <!-- Microsoft.Extensions.* -->
     <PackageVersion_Microsoft_Extensions>8.0.0</PackageVersion_Microsoft_Extensions>
-    <PackageVersion_Microsoft_Extensions Condition="'$(TargetFramework)'=='net7.0'">7.0.0</PackageVersion_Microsoft_Extensions>
-    <PackageVersion_Microsoft_Extensions Condition="'$(TargetFramework)'=='net6.0'">6.0.0</PackageVersion_Microsoft_Extensions>
-    <PackageVersion_Microsoft_Extensions Condition="$(TargetFramework.StartsWith('netstandard2')) Or '$(TargetFramework)'=='netcoreapp3.1'">3.1.26</PackageVersion_Microsoft_Extensions>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">
+    <PackageVersion_Microsoft_Extensions>7.0.0</PackageVersion_Microsoft_Extensions>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <PackageVersion_Microsoft_Extensions>6.0.0</PackageVersion_Microsoft_Extensions>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard2')) Or '$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageVersion_Microsoft_Extensions>3.1.26</PackageVersion_Microsoft_Extensions>
   </PropertyGroup>
 
 </Project>

--- a/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
+++ b/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
@@ -6,14 +6,29 @@
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Microsoft_AspNetCore_Mvc_Testing>8.0.0</Microsoft_AspNetCore_Mvc_Testing>
+    <Serilog_AspNetCore>8.0.0</Serilog_AspNetCore>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">
+    <Microsoft_AspNetCore_Mvc_Testing>7.0.10</Microsoft_AspNetCore_Mvc_Testing>
+    <Serilog_AspNetCore>7.0.0</Serilog_AspNetCore>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <Microsoft_AspNetCore_Mvc_Testing>6.0.21</Microsoft_AspNetCore_Mvc_Testing>
+    <Serilog_AspNetCore>6.1.0</Serilog_AspNetCore>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <Microsoft_AspNetCore_Mvc_Testing>3.1.32</Microsoft_AspNetCore_Mvc_Testing>
+    <Serilog_AspNetCore>6.1.0</Serilog_AspNetCore>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" Condition="'$(TargetFramework)'=='net8.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" Condition="'$(TargetFramework)'=='net7.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" Condition="'$(TargetFramework)'=='net6.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.32" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" Condition="'$(TargetFramework)'=='net8.0'" />
-    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" Condition="'$(TargetFramework)'!='net8.0' And '$(TargetFramework)'!='net7.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(Microsoft_AspNetCore_Mvc_Testing)" />
+    <PackageReference Include="Serilog.AspNetCore" Version="$(Serilog_AspNetCore)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Correlate.Testing/Correlate.Testing.csproj
+++ b/test/Correlate.Testing/Correlate.Testing.csproj
@@ -1,20 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Serilog_Extensions_Logging>8.0.0</Serilog_Extensions_Logging>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">
+    <Serilog_Extensions_Logging>7.0.0</Serilog_Extensions_Logging>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <Serilog_Extensions_Logging>3.1.0</Serilog_Extensions_Logging>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard2')) Or '$(TargetFramework)'=='netcoreapp3.1'">
+    <Serilog_Extensions_Logging>3.1.0</Serilog_Extensions_Logging>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(PackageVersion_Microsoft_Extensions)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(PackageVersion_Microsoft_Extensions)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)'=='net8.0'" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" Condition="'$(TargetFramework)'!='net8.0' And '$(TargetFramework)'!='net7.0'" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="$(Serilog_Extensions_Logging)" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="skwas.MockHttp" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
An attempt to make dependabot offer correct PR's. Currently it seems to struggle with custom properties icw. conditions and even mixes up wrong dependencies in the diff because of it.

See for example #101 where it attempts to update xunit but gets it all wrong.

By reorganizing, the way we override the custom properties, hopefully dependabot understands this better.