### PR TITLE
feat: Add ToString override to CorrelatedLogScope

### DIFF
--- a/src/Correlate.Core/Extensions/LoggerExtensions.cs
+++ b/src/Correlate.Core/Extensions/LoggerExtensions.cs
@@ -49,5 +49,14 @@ internal static class LoggerExtensions
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
+
+        /// <summary>
+        /// Returns a representation of the scope items as a list of comma-separated items,
+        /// matching the default representation provided by the standard Console logger.
+        /// </summary>
+        public override string ToString()
+        {
+            return string.Join(", ", this.Select(kv => $"{kv.Key}:{kv.Value}"));
+        }
     }
 }

--- a/src/Correlate.Core/Extensions/LoggerExtensions.cs
+++ b/src/Correlate.Core/Extensions/LoggerExtensions.cs
@@ -56,7 +56,7 @@ internal static class LoggerExtensions
         /// </summary>
         public override string ToString()
         {
-            return string.Join(", ", this.Select(kv => $"{kv.Key}:{kv.Value}"));
+            return _scopeKey + ':' + _correlationId;
         }
     }
 }

--- a/test/Correlate.Core.Tests/Extensions/LoggerExtensionsTests.cs
+++ b/test/Correlate.Core.Tests/Extensions/LoggerExtensionsTests.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Correlate.Extensions;
+
+public sealed class LoggerExtensionsTests
+{
+    private readonly ILogger _logger;
+
+    public LoggerExtensionsTests()
+    {
+        _logger = Substitute.For<ILogger>();
+    }
+
+    [Theory]
+    [InlineData(CorrelateConstants.CorrelationIdKey, "12345")]
+    [InlineData("CustomKey", "abcdef")]
+    public void When_beginning_scope_it_should_return_disposable_scope_implementing_kvp_list_containing_the_correlation_id
+    (
+        string scopeKey,
+        string correlationId
+    )
+    {
+        var expectedKvp = new KeyValuePair<string, object>(scopeKey, correlationId);
+
+        Func<IReadOnlyList<KeyValuePair<string, object>>, bool> assertScope = kvps =>
+        {
+            kvps.Should()
+                .ContainSingle()
+                .Which.Should()
+                .Be(expectedKvp);
+            return true;
+        };
+
+        // Act
+        _logger.BeginCorrelatedScope(scopeKey, correlationId);
+
+        // Assert
+        _logger.Received(1).BeginScope(Arg.Is<IReadOnlyList<KeyValuePair<string, object>>>(e => assertScope(e)));
+    }
+
+    [Theory]
+    [InlineData(CorrelateConstants.CorrelationIdKey, "12345")]
+    [InlineData("CustomKey", "abcdef")]
+    public void When_formatting_scope_it_should_return_expected
+    (
+        string scopeKey,
+        string correlationId
+    )
+    {
+        string expectedStr = $"{scopeKey}:{correlationId}";
+
+        Func<object, bool> assertScope = formattable =>
+        {
+            formattable.ToString().Should().Be(expectedStr);
+            return true;
+        };
+
+        // Act
+        _logger.BeginCorrelatedScope(scopeKey, correlationId);
+
+        // Assert
+        _logger.Received(1).BeginScope(Arg.Is<object>(e => assertScope(e)));
+    }
+}


### PR DESCRIPTION
Output to the default `Console` logger uses `ToString` on scope items. Without the override, the default output of the correlated scope is
```
...
 => Correlate.Extensions.LoggerExtensions+CorrelatedLogScope
...
```
when the output should be 
```
 => CorrelationId:8157ca4b-38e2-4748-b9aa-df5b2c4d4340
```

The proposed override formats the output in a similar way to the Console logger.