### PR TITLE
chore: removed .NET Core 3.1 target framework from Correlate.AspNetCore (EOL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ Please consider that .NET Core 3.1 and up now has built-in support for [W3C Trac
 
 ### Supported .NET targets
 - .NET 6.0, .NET 8.0
-- .NET Standard 2.0/.NET Core 3.1
+- .NET Standard 2.0
 
 ### ASP.NET Core support
 - ASP.NET Core 6.0/8.0
 
-### Build requirements
+### Build/test requirements
 - Visual Studio 2022
 - .NET 8 SDK
 - .NET 6 SDK

--- a/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
+++ b/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
 

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/IntegrationTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/IntegrationTests.cs
@@ -39,14 +39,6 @@ public sealed class IntegrationTests : IClassFixture<TestAppFactory<Startup>>, I
 
     public void Dispose()
     {
-#if NETCOREAPP3_1
-        // NET Core 3.1 test host does not trigger application stopping token, but our diagnostics observable
-        // (subscribed in UseCorrelate) must unsubscribe before next test run.
-        // This is a bit crude but later versions of .NET test host do it properly.
-        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
-        IHostApplicationLifetime? appLifetime = _factory?.Services.GetRequiredService<IHostApplicationLifetime>();
-        appLifetime?.StopApplication();
-#endif
         // ReSharper disable ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
         _factory?.Dispose();
         _mockHttp?.Dispose();

--- a/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
+++ b/test/Correlate.AspNetCore.Tests/Correlate.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>
   </PropertyGroup>
@@ -13,11 +13,6 @@
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
     <Microsoft_AspNetCore_Mvc_Testing>6.0.21</Microsoft_AspNetCore_Mvc_Testing>
-    <Serilog_AspNetCore>6.1.0</Serilog_AspNetCore>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <Microsoft_AspNetCore_Mvc_Testing>3.1.32</Microsoft_AspNetCore_Mvc_Testing>
     <Serilog_AspNetCore>6.1.0</Serilog_AspNetCore>
   </PropertyGroup>
 


### PR DESCRIPTION
Removed .NET Core 3.1 target framework from Correlate.AspNetCore. The SDK is still used in unit tests to cover the .NET Standard 2.x target framework for published packages, so it is not removed from CI setup either.