### PR TITLE
ci: install ICU (missing from latest ubuntu 24.04 image)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,12 +96,16 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-13
+        include:
+          - os: ubuntu-latest
+            # https://forum.manjaro.org/t/dotnet-3-1-builds-fail-after-icu-system-package-updated-to-71-1-1/114232
+            CLR_ICU_VERSION_OVERRIDE: "71.1"
+          - os: windows-latest
+          - os: macos-13
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    env:
+      CLR_ICU_VERSION_OVERRIDE: ${{matrix.CLR_ICU_VERSION_OVERRIDE}}
     steps:
       # Setup
       - uses: actions/setup-dotnet@v4

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -31,6 +31,8 @@ jobs:
   analysis:
     needs: authorize
     runs-on: ubuntu-latest
+    env:
+      CLR_ICU_VERSION_OVERRIDE: "71.1"
     steps:
       - uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
Fixes the issue that now occurs in CI with the latest Ubuntu image.

```
Testhost process for source(s) '/home/runner/work/Correlate/Correlate/test/Correlate.DependencyInjection.Tests/bin/Release/netcoreapp3.1/Correlate.DependencyInjection.Tests.dll' exited with error: Process terminated. Couldn't find a valid ICU package installed on the system. Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.
```

https://github.com/skwasjer/Correlate/actions/runs/12337396718/job/34431074586

