### PR TITLE
ci: use pinned Ubuntu 22.04 image for tests 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - windows-latest
           - macos-13
       fail-fast: false

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
 
   analysis:
     needs: authorize
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
Fixes ICU missing and mono not being available.

⚠️
1. Requires repo merge check to be updated (from `test (ubuntu-latest)` to `test (ubuntu-22.04)`
2. The sonar workflow will run from `main` branch and thus will still fail in this context.

