### PR TITLE
test: replace .NET Core 3.1 with .NET 6.0

### DIFF
--- a/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
+++ b/test/Correlate.Core.Tests/Correlate.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(NetPreview)'=='true'">$(TargetFrameworks);netx.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Correlate</RootNamespace>

--- a/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
+++ b/test/Correlate.DependencyInjection.Tests/Correlate.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(NetPreview)'=='true'">$(TargetFrameworks);netx.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Correlate.DependencyInjection</RootNamespace>

--- a/test/Correlate.DependencyInjection.Tests/IHttpClientBuilderExtensionsTests.cs
+++ b/test/Correlate.DependencyInjection.Tests/IHttpClientBuilderExtensionsTests.cs
@@ -60,11 +60,7 @@ public class When_adding_correlation_delegating_handler_to_httpClient
 
             // AddHttpMessageHandler with options:
             yield return new ExpectedRegistration<IConfigureOptions<CorrelateClientOptions>, ConfigureNamedOptions<CorrelateClientOptions>>(ServiceLifetime.Singleton);
-#if NETCOREAPP3_1_OR_GREATER
             yield return new ExpectedRegistration<IConfigureOptions<HttpClientFactoryOptions>>(ServiceLifetime.Singleton);
-#else
-				yield return new ExpectedRegistration<IConfigureOptions<HttpClientFactoryOptions>>(ServiceLifetime.Transient);
-#endif
             yield return new ExpectedRegistration<MyService>(ServiceLifetime.Transient);
         }
     }

--- a/test/Correlate.Testing/Correlate.Testing.csproj
+++ b/test/Correlate.Testing/Correlate.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(NetPreview)'=='true'">$(TargetFrameworks);netx.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <Serilog_Extensions_Logging>8.0.0</Serilog_Extensions_Logging>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard2')) Or '$(TargetFramework)'=='netcoreapp3.1'">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard2')) Or '$(TargetFramework)'=='net6.0'">
     <Serilog_Extensions_Logging>3.1.0</Serilog_Extensions_Logging>
   </PropertyGroup>
 


### PR DESCRIPTION
Addresses some EOL warnings/test failures in CI. 

> .NET 6 is used to unit test the .NET Standard 2.0 packages.

Even though .NET 6.x itself is also EOL, it is far newer than 3.1 and solves some pain with dependencies and also allows us to remove some other test boilerplate (in follow up).