### PR TITLE
docs: update README's and add to nuspec 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Correlate
 
-Correlate provides flexible .NET Core support for correlation ID in ASP.NET Core and HttpClient.
+Correlate provides flexible .NET support (ASP.NET Core/HttpClient) to correlate activities between decoupled components (eg. microservices) using a correlation ID.
 
 ## Installation
 
@@ -31,7 +31,7 @@ dotnet add package Correlate.AspNetCore
 
 ## Usage
 
-In an ASP.NET Core (MVC) application, register Correlate to handle incoming requests with a correlation id. Correlate will create a request scoped async context holding the correlation id, which can then propagate down the request pipeline.
+In an ASP.NET Core application, register Correlate to handle incoming requests with a correlation id. Correlate will create a request scoped async context holding the correlation id, which can then propagate down the request pipeline.
 
 When using `HttpClient` to call other services, you can use `HttpClientFactory` to attach a delegating handler to any `HttpClient` which will propagate the correlation id header to the outgoing request for cross service correlation. Further more, there are other integration packages that also propagate the correlation id to other transports (see down below).
 
@@ -51,12 +51,11 @@ public class Startup
     {
         // Register services.
         services.AddCorrelate(options => 
-            options.RequestHeaders = new []
-            {
+            options.RequestHeaders = [
               // List of incoming headers possible. First that is set on given request is used and also returned in the response.
               "X-Correlation-ID",
               "My-Correlation-ID"
-            }
+            ]
         );
 
         // Register a typed client that will include the correlation id in outgoing request.
@@ -171,7 +170,7 @@ await _correlationManager.CorrelateAsync(orderId, () => {
 - `ICorrelationManager`
 - `IAsyncCorrelationManager`
 
-> Note that the Correlate internals are intrinsically asynchronous as it relies on [`AsyncLocal<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1) to save the correlation context. The synchronous implementation is useful for integrations that have a synchronous API surface but are still used in asynchronous context, but should only be used as such.
+> Note that the Correlate internals are intrinsically asynchronous as it relies on [`AsyncLocal<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1) to save the correlation context. The synchronous implementation is useful for integrations that have a synchronous API surface but are still used in asynchronous context, and thus Correlate should only be used as such.
 
 ## ICorrelationIdFactory
 
@@ -212,7 +211,7 @@ Please consider that since .NET Core 3.1 and up there is built-in support for [W
 - Visual Studio 2022
 - .NET 9 SDK
 - .NET 8 SDK
-- .NET 3.1 SDK
+- .NET 6.0 SDK
 
 #### Contributions
 PR's are welcome. Please rebase before submitting, provide test coverage, and ensure the AppVeyor build passes. I will not consider PR's otherwise.

--- a/src/Correlate.Abstractions/Correlate.Abstractions.csproj
+++ b/src/Correlate.Abstractions/Correlate.Abstractions.csproj
@@ -10,6 +10,7 @@
     <Description>Provides abstractions to correlate requests between microservices.</Description>
     <PackageProjectUrl>https://github.com/skwasjer/Correlate</PackageProjectUrl>
     <PackageTags>correlationid, correlation, correlate, causation, aspnet, middleware, httpclient, httpclientfactory</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Correlate.Abstractions/README.md
+++ b/src/Correlate.Abstractions/README.md
@@ -1,4 +1,4 @@
-ASP.NET Core middleware component to correlate requests between microservices using correlation ID request headers.
+Abstractions to correlate activities between decoupled components (eg. microservices).
 
 ### Useful links
 

--- a/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
+++ b/src/Correlate.AspNetCore/Correlate.AspNetCore.csproj
@@ -10,6 +10,7 @@
     <Description>ASP.NET Core middleware component to correlate requests between microservices using correlation ID request headers.</Description>
     <PackageProjectUrl>https://github.com/skwasjer/Correlate</PackageProjectUrl>
     <PackageTags>correlationid, correlation, correlate, causation, aspnet, middleware, httpclient, httpclientfactory</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Correlate.AspNetCore/README.md
+++ b/src/Correlate.AspNetCore/README.md
@@ -1,8 +1,4 @@
-Provides abstractions to correlate requests between microservices.
-
-### Migration from v4.x to 5.0.0
-
-- Replace `Correlate.AspNetCore.Middleware` namespace with `Correlate.AspNetCore`.
+An ASP.NET Core implementation to correlate activities between decoupled components (eg. microservices) via a HTTP header.
 
 ### Useful links
 

--- a/src/Correlate.Core/Correlate.Core.csproj
+++ b/src/Correlate.Core/Correlate.Core.csproj
@@ -12,6 +12,7 @@
     <Description>Correlate requests between microservices using a correlation ID.</Description>
     <PackageProjectUrl>https://github.com/skwasjer/Correlate</PackageProjectUrl>
     <PackageTags>correlationid, correlation, correlate, causation, aspnet, middleware, httpclient, httpclientfactory</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Correlate.Core/README.md
+++ b/src/Correlate.Core/README.md
@@ -1,4 +1,4 @@
-Correlate requests between microservices using a correlation ID.
+The core implementation to correlate activities between decoupled components (eg. microservices) using a correlation ID.
 
 ### Useful links
 

--- a/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
+++ b/src/Correlate.DependencyInjection/Correlate.DependencyInjection.csproj
@@ -9,6 +9,7 @@
     <Description>Dependency injection extensions for Correlate.</Description>
     <PackageProjectUrl>https://github.com/skwasjer/Correlate</PackageProjectUrl>
     <PackageTags>correlationid, correlation, correlate, causation, aspnet, middleware, httpclient, httpclientfactory</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Correlate.DependencyInjection/README.md
+++ b/src/Correlate.DependencyInjection/README.md
@@ -1,4 +1,4 @@
-Dependency injection extensions for Correlate.
+Dependency injection extensions to register the Correlate services.
 
 ### Dependency registration example
 


### PR DESCRIPTION
Improves docs and fixes 'Your package is missing a README.' on nuget.org.