### PR TITLE
fix!: remove default value from CorrelateOptions.RequestHeaders

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
-    <NoWarn>$(NoWarn);IDE0079;S1135;CA1510;CA1511;CA1512;CA1513;CA1863</NoWarn>
+    <NoWarn>$(NoWarn);IDE0079;S1135;CA1510;CA1511;CA1512;CA1513;CA1863;xUnit1042</NoWarn>
     <NoWarn Condition="'$(Configuration)'=='Release'">$(NoWarn);NETSDK1138</NoWarn>
     <WarningsAsErrors>$(WarningsAsErrors);NU1601;NU1603;NU1605;NU1608;NU1701;MSB3644</WarningsAsErrors>
     <ContinuousIntegrationBuild Condition="'$(CI)'!=''">true</ContinuousIntegrationBuild>

--- a/src/Correlate.AspNetCore/AspNetCore/CorrelateFeature.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/CorrelateFeature.cs
@@ -1,4 +1,5 @@
-﻿using Correlate.Http.Extensions;
+﻿using Correlate.Http;
+using Correlate.Http.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -88,7 +89,7 @@ internal sealed class CorrelateFeature
 
     private (string? headerName, string correlationId) GetOrCreateCorrelationHeaderAndId(HttpContext httpContext)
     {
-        (string requestHeaderName, string? requestCorrelationId) = httpContext.Request.Headers.GetCorrelationIdHeader(_options.RequestHeaders);
+        (string requestHeaderName, string? requestCorrelationId) = httpContext.Request.Headers.GetCorrelationIdHeader(_options.RequestHeaders ?? [CorrelationHttpHeaders.CorrelationId]);
         if (requestCorrelationId is not null)
         {
             LogRequestHeaderFound(_logger, requestHeaderName, requestCorrelationId, null);

--- a/src/Correlate.AspNetCore/AspNetCore/CorrelateOptions.cs
+++ b/src/Correlate.AspNetCore/AspNetCore/CorrelateOptions.cs
@@ -1,27 +1,21 @@
-﻿using Correlate.Http;
-
-namespace Correlate.AspNetCore;
+﻿namespace Correlate.AspNetCore;
 
 /// <summary>
 /// Options for handling correlation id on incoming requests.
 /// </summary>
-public sealed class CorrelateOptions: CorrelationManagerOptions
+public sealed class CorrelateOptions : CorrelationManagerOptions
 {
-    private static readonly string[] DefaultRequestHeaders = { CorrelationHttpHeaders.CorrelationId };
-
-    private string[]? _requestHeaders;
-
     /// <summary>
-    /// Gets or sets the request headers to retrieve the correlation id from. Defaults to <c>X-Correlation-ID</c>.
+    /// Gets or sets the request headers to retrieve the correlation id from.
+    /// <para>
+    /// To disable using the correlation ID from an incoming request, explicitly set this to an empty list.
+    /// When <see langword="null" />, internally defaults to <c>["X-Correlation-ID"]</c>.
+    /// </para>
     /// </summary>
     /// <remarks>
     /// The first matching request header will be used.
     /// </remarks>
-    public string[] RequestHeaders
-    {
-        get => _requestHeaders ?? DefaultRequestHeaders;
-        set => _requestHeaders = value;
-    }
+    public IReadOnlyList<string>? RequestHeaders { get; set; }
 
     /// <summary>
     /// Gets or sets whether to include the correlation id in the response.

--- a/src/Correlate.Core/Http/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Correlate.Core/Http/Extensions/HeaderDictionaryExtensions.cs
@@ -4,7 +4,7 @@ namespace Correlate.Http.Extensions;
 
 internal static class HeaderDictionaryExtensions
 {
-    internal static KeyValuePair<string, string?> GetCorrelationIdHeader(this IDictionary<string, StringValues> httpHeaders, ICollection<string> acceptedHeaders)
+    internal static KeyValuePair<string, string?> GetCorrelationIdHeader(this IDictionary<string, StringValues> httpHeaders, IReadOnlyCollection<string> acceptedHeaders)
     {
         if (acceptedHeaders is null)
         {

--- a/test/Correlate.AspNetCore.Tests/AspNetCore/CorrelateFeatureTests.cs
+++ b/test/Correlate.AspNetCore.Tests/AspNetCore/CorrelateFeatureTests.cs
@@ -42,7 +42,7 @@ public sealed class CorrelateFeatureTests : IDisposable
         _correlationIdFactory = Substitute.For<ICorrelationIdFactory>();
         _correlationIdFactory.Create().Returns(CorrelationId);
 
-        _options = new CorrelateOptions();
+        _options = new CorrelateOptions { RequestHeaders = [CorrelationHttpHeaders.CorrelationId] };
         _sut = new CorrelateFeature(
             _services.GetRequiredService<ILoggerFactory>(),
             _correlationIdFactory,
@@ -67,11 +67,11 @@ public sealed class CorrelateFeatureTests : IDisposable
         _options.RequestHeaders.Should().NotBeNullOrEmpty();
         if (requestHeader is not null)
         {
-            _options.RequestHeaders = new[] { requestHeader };
+            _options.RequestHeaders = [requestHeader];
         }
 
         var expectedHeader = new KeyValuePair<string, StringValues>(
-            _options.RequestHeaders[0],
+            _options.RequestHeaders![0],
             new StringValues(CorrelationId)
         );
 
@@ -91,7 +91,7 @@ public sealed class CorrelateFeatureTests : IDisposable
     [InlineData(CorrelationHttpHeaders.RequestId)]
     public async Task Given_that_request_contains_correlationId_header_in_allowed_list_when_correlating_has_started_it_should_have_used_that_correlationId(string headerName)
     {
-        _options.RequestHeaders = new[] { CorrelationHttpHeaders.CorrelationId, CorrelationHttpHeaders.RequestId };
+        _options.RequestHeaders = [CorrelationHttpHeaders.CorrelationId, CorrelationHttpHeaders.RequestId];
 
         string correlationId = Guid.NewGuid().ToString("D");
         _httpContext.Features.Get<IHttpRequestFeature>()!
@@ -203,7 +203,7 @@ public sealed class CorrelateFeatureTests : IDisposable
         _options.RequestHeaders.Should().NotBeNullOrEmpty();
 
         const string existingCorrelationId = "existing-id";
-        _responseFeature.Headers.Append(_options.RequestHeaders[0], existingCorrelationId);
+        _responseFeature.Headers.Append(_options.RequestHeaders![0], existingCorrelationId);
 
         var expectedHeader = new KeyValuePair<string, StringValues>(
             _options.RequestHeaders[0],


### PR DESCRIPTION
Removes default value from `CorrelateOptions.RequestHeaders` to allow proper configuration binding (from env vars/json).

This is a breaking change since the property `RequestHeaders` is now also nullable. When the property value is null, we can still use the default value inlined. Explicitly setting the property to an empty list effectively still disables this feature as before.

Fixes #128