### PR TITLE
refactor: header collections of different types

### DIFF
--- a/src/Correlate.Core/Http/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Correlate.Core/Http/Extensions/HeaderDictionaryExtensions.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.Extensions.Primitives;
-
-namespace Correlate.Http.Extensions;
+﻿namespace Correlate.Http.Extensions;
 
 internal static class HeaderDictionaryExtensions
 {
-    internal static KeyValuePair<string, string?> GetCorrelationIdHeader(this IDictionary<string, StringValues> httpHeaders, IReadOnlyCollection<string> acceptedHeaders)
+    internal static KeyValuePair<string, string?> GetCorrelationIdHeader<THeaderValue>(this IDictionary<string, THeaderValue> httpHeaders, IReadOnlyCollection<string> acceptedHeaders)
     {
         if (acceptedHeaders is null)
         {
@@ -21,13 +19,15 @@ internal static class HeaderDictionaryExtensions
 
         foreach (string requestHeaderName in acceptedHeaders)
         {
-            if (!httpHeaders.TryGetValue(requestHeaderName, out StringValues value))
+            if (!httpHeaders.TryGetValue(requestHeaderName, out THeaderValue? value))
             {
                 continue;
             }
 
             headerName = requestHeaderName;
-            correlationId = value.LastOrDefault();
+            correlationId = value is IEnumerable<string> multiValue
+                ? multiValue.LastOrDefault()
+                : value?.ToString();
             if (!string.IsNullOrWhiteSpace(correlationId))
             {
                 break;


### PR DESCRIPTION
The extension now has generic header value, so that it can be used on dictionaries of `StringValues`, `string?[]?` and `string?`. This makes it easier to use with different HTTP header collection implementations