### PR TITLE
docs: missing X-Frame-Options HTTP header

### DIFF
--- a/examples/WebApiTestNet48/Web.config
+++ b/examples/WebApiTestNet48/Web.config
@@ -11,6 +11,11 @@
     <modules>
       <add name="CorrelateHttpModule" type="Correlate.AspNet.CorrelateHttpModule, Correlate.AspNet.WebApi" />
     </modules>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="DENY" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <system.web>
     <httpModules>


### PR DESCRIPTION
Fixes CodeQL security scan warning. (low risk, since this is example code)